### PR TITLE
Add a random label to the pods when configured to do so (forces reloa…

### DIFF
--- a/charts/postgreslet/templates/deployment.yaml
+++ b/charts/postgreslet/templates/deployment.yaml
@@ -21,6 +21,9 @@ spec:
       {{- end }}
       labels:
         control-plane: controller-manager
+{{- if .Values.addRandomLabel }}
+        random-label-to-force-reload: {{ randAlphaNum 12 | quote }}
+{{- end }}
         {{- include "postgreslet.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}

--- a/charts/postgreslet/values.yaml
+++ b/charts/postgreslet/values.yaml
@@ -76,3 +76,7 @@ postgreslet:
   # customPspName The name to use for our custom psp
   # If not set, a name is generated using the fullname template
   customPspName: ""
+
+# addRandomLabel adds a random label each time the deployment.yaml is rendered, forcing k8s to update that deployment.
+# In combination with image.PullPolicy=Always, this effetifely forces a reload of the pod, even if the image tag stays the same.
+addRandomLabel: false


### PR DESCRIPTION
…d of pod, which can be used in combination with image.pullPolicy=Always to force a reload of the used image)