### PR TITLE
WIP: Add a reference to the zalando resource in the status

### DIFF
--- a/api/v1/postgres_types.go
+++ b/api/v1/postgres_types.go
@@ -150,6 +150,8 @@ type PostgresStatus struct {
 	Description string `json:"description,omitempty"`
 
 	Socket Socket `json:"socket,omitempty"`
+
+	ChildReference string `json:"childReference,omitempty"`
 }
 
 // Socket represents load-balancer socket of Postgres

--- a/config/crd/bases/database.fits.cloud_postgres.yaml
+++ b/config/crd/bases/database.fits.cloud_postgres.yaml
@@ -59,22 +59,6 @@ spec:
                       type: string
                     type: array
                 type: object
-              backup:
-                description: 'todo: add default Backup parametes of the database backup'
-                properties:
-                  retention:
-                    description: Retention defines how many days a backup will persist
-                    format: int32
-                    type: integer
-                  s3BucketURL:
-                    description: S3BucketURL defines the URL of the S3 bucket for
-                      backup
-                    type: string
-                  schedule:
-                    description: Schedule defines how often a backup should be made,
-                      in cron format
-                    type: string
-                type: object
               description:
                 description: Description
                 type: string
@@ -141,6 +125,8 @@ spec:
           status:
             description: PostgresStatus defines the observed state of Postgres
             properties:
+              childReference:
+                type: string
               description:
                 description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
                   of cluster Important: Run "make" to regenerate code after modifying

--- a/controllers/status_controller.go
+++ b/controllers/status_controller.go
@@ -82,7 +82,10 @@ func (r *StatusReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		if err := r.Control.Get(ctx, types.NamespacedName{Name: owner.Name, Namespace: owner.Namespace}, &owner); err != nil {
 			return err
 		}
+		// update the status of the remote object
 		owner.Status.Description = instance.Status.PostgresClusterStatus
+		// update the reference to the zalando instance in the remote object
+		owner.Status.ChildReference = string(instance.UID)
 
 		log.Info("Updating owner", "owner", owner)
 		if err := r.Control.Status().Update(ctx, &owner); err != nil {


### PR DESCRIPTION
As a means to obtain the intern UID of the zalando resource via `cloudctl`/`cloud-api`, we write that UID in the status part of our `postgres` resource.

I gave it a general name of `ChildReference` to hide the actual implementation detail of which operator we use, just in case it might change in the future.