### PR TITLE
Remove IsAlreadyExists check

### DIFF
--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -371,7 +371,7 @@ func (r *PostgresReconciler) createOrUpdateCWNP(ctx context.Context, in *pg.Post
 	if _, err := controllerutil.CreateOrUpdate(ctx, r.Service, key, func() error {
 		key.Spec.Ingress = policy.Spec.Ingress
 		return nil
-	}); err != nil && !errors.IsAlreadyExists(err) {
+	}); err != nil {
 		return fmt.Errorf("unable to deploy CRD ClusterwideNetworkPolicy: %w", err)
 	}
 


### PR DESCRIPTION
[`CreateOrUpdate`](https://github.com/kubernetes-sigs/controller-runtime/blob/1d02366cf7fcca0c3993effbafea1d78cc48f55a/pkg/controller/controllerutil/controllerutil.go#L206) checks the existence of the object first. Not possible for error `StatusReasonAlreadyExists` to occur.