### PR TITLE
Turn on leader-election

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ Install the Postgreslet to the service cluster
 
 ```sh
 make kind-load-image
+
+# only for local dev
+make install-crd-cwnp
+
 kubectl create namespace postgreslet-system
 helm upgrade --install postgreslet postgreslet-0.1.0.tgz --namespace postgreslet-system --set-file controlplaneKubeconfig=kubeconfig  --set image.tag=latest
 kubectl get po -A --watch

--- a/charts/postgreslet/values.yaml
+++ b/charts/postgreslet/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
+replicaCount: 2
 
 image:
   repository: r.metal-stack.io/postgreslet
@@ -59,7 +59,7 @@ terminationGracePeriodSeconds: 10
 
 postgreslet:
   # enableLeaderElection specifies weather leader election should be performed
-  enableLeaderElection: false
+  enableLeaderElection: true
   # partitionId specifies which partition this postgreslet is responsable for, postgres resources from other partitions will be ignored
   partitionId: sample-partition
   # tenant specifies which tenant this postgreslet is responsable for, postgres resources from other tenants will be ignored

--- a/config/manager/configmap.yaml
+++ b/config/manager/configmap.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  ENABLE_LEADER_ELECTION: "false"
+  ENABLE_LEADER_ELECTION: "true"
   METRICS_ADDR_CTRL_MGR: "0"
   METRICS_ADDR_SVC_MGR: ":8080"
   PARTITION_ID: sample-partition

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -16,7 +16,7 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       labels:

--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ func main() {
 	var portRangeStart, portRangeSize int
 	flag.StringVar(&metricsAddrSvcMgr, "metrics-addr-svc-mgr", ":8080", "The address the metric endpoint of the service cluster manager binds to.")
 	flag.StringVar(&metricsAddrCtrlMgr, "metrics-addr-ctrl-mgr", "0", "The address the metric endpoint of the control cluster manager binds to.")
-	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
+	flag.BoolVar(&enableLeaderElection, "enable-leader-election", true,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&partitionID, "partition-id", "", "The partition ID of the worker-cluster.")


### PR DESCRIPTION
Closes #55
Tested with `make deploy` and `helm upgrade --install postgreslet postgreslet-0.1.0.tgz --namespace postgreslet-system --set-file controlplaneKubeconfig=kubeconfig  --set image.tag=latest` locally. Both worked in the sense that two pods of *postgreslet* were deployed and creation and deletion of `Postgres` worked as normal.