### PR TITLE
Use func `BuildConfigFromFlags`

### DIFF
--- a/main.go
+++ b/main.go
@@ -109,10 +109,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	ctrlPlaneClusterConf, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		&clientcmd.ClientConfigLoadingRules{ExplicitPath: ctrlClusterKubeconfig},
-		&clientcmd.ConfigOverrides{},
-	).ClientConfig()
+	ctrlPlaneClusterConf, err := clientcmd.BuildConfigFromFlags("", ctrlClusterKubeconfig)
 	if err != nil {
 		setupLog.Error(err, "unable to get control cluster kubeconfig")
 		os.Exit(1)


### PR DESCRIPTION
`BuildConfigFromFlags` is from the same package as `NewNonInteractiveDeferredLoadingClientConfig`, but the former communicates its intention better than the latter which is lower-level.