### PR TITLE
Remove redundant code

### DIFF
--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -241,8 +241,7 @@ func (r *PostgresReconciler) ensureZalandoDependencies(ctx context.Context, p *p
 	}
 
 	if !isInstalled {
-		_, err := r.InstallOrUpdateOperator(ctx, namespace)
-		if err != nil {
+		if err := r.InstallOrUpdateOperator(ctx, namespace); err != nil {
 			return fmt.Errorf("error while installing zalando dependencies: %w", err)
 		}
 	}


### PR DESCRIPTION
We don't need the slice of `runtime.Object`s anymore. The original idea was to record what we created and deleted them when the operator is deleted. However, the implementation of the deletion was changed a long time ago. Therefore, the logic related to redundant `objs` is removed entirely. `make test` passed.