### PR TITLE
Add test to GitHub workflows experimental

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -18,11 +18,8 @@ jobs:
         version: v1.32.2
         args: --timeout=5m
 
-    - name: Install Kubebuilder
-      run: make kubebuilder
-
     - name: Run tests
-      run: make test
+      run: make test-ci
 
     - name: Figure out if running fork PR
       id: fork

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -18,9 +18,6 @@ jobs:
         version: v1.32.2
         args: --timeout=5m
 
-    - name: Run tests
-      run: make test-ci
-
     - name: Figure out if running fork PR
       id: fork
       run: '["${{ secrets.DOCKER_REGISTRY_TOKEN }}" == ""] && echo "::set-output name=is_fork_pr::true" || echo "::set-output name=is_fork_pr::false"'
@@ -32,6 +29,9 @@ jobs:
         username: ${{ secrets.DOCKER_REGISTRY_USER }}
         password: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
       if: steps.fork.outputs.is_fork_pr == 'false'
+
+    - name: Run tests
+      run: make test-ci
 
     - name: Build Docker image
       run: |

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -28,6 +28,9 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go test ./controllers -
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/controllers.test .
+COPY --from=builder /usr/local/kubebuilder/bin /usr/local/kubebuilder/bin
+COPY external external
+COPY config config
 USER nonroot:nonroot
 
 ENTRYPOINT ["/controllers.test"]

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -1,0 +1,33 @@
+# Build the manager binary
+FROM golang:1.16 as builder
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the go source
+COPY api/ api/
+COPY controllers/ controllers/
+COPY pkg/ pkg/
+COPY external external
+COPY config config
+
+RUN curl -L https://go.kubebuilder.io/dl/2.3.1/linux/amd64 | tar -xz -C /tmp/ ;\
+	mv /tmp/kubebuilder_2.3.1_linux_amd64 /usr/local/kubebuilder ;\
+	export PATH=$PATH:/usr/local/kubebuilder/bin
+
+# Build
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go test ./controllers -c
+
+# Use distroless as minimal base image to package the manager binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+COPY --from=builder /workspace/controllers.test .
+USER nonroot:nonroot
+
+ENTRYPOINT ["/controllers.test"]

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,17 @@ POSTGRES_CRD_URL ?= https://raw.githubusercontent.com/zalando/postgres-operator/
 all: manager
 
 # Run tests
-test: generate fmt vet manifests
+test: test-prep
 	go test ./... -coverprofile cover.out -v
+
+test-ci: test-ci-prep
+	docker run --rm ${IMG}:test-ci
+
+test-ci-prep: test-prep
+	docker build -f Dockerfile-test -t ${IMG}:test-ci .
+	docker push ${IMG}:test-ci
+
+test-prep: generate fmt vet manifests
 
 # todo: Modify Dockerfile to include the version magic
 # Build manager binary


### PR DESCRIPTION
This approach also works, but we still have to download `kubebuilder` each time we build the *test* image. In addition to that, now we have to download the *go* dependencies twice.