### PR TITLE
Use `createOrUpdate` pattern

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -100,6 +100,7 @@ var _ = BeforeSuite(func(done Done) {
 
 	// Todo: OperatorManager should be a reconciler
 	opMgr, err := operatormanager.New(
+		ctrlClusterMgr.GetClient(),
 		svcClusterCfg,
 		filepath.Join(externalYAMLDir, "svc-postgres-operator.yaml"),
 		scheme,

--- a/main.go
+++ b/main.go
@@ -130,7 +130,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	opMgr, err := operatormanager.New(svcClusterConf, "external/svc-postgres-operator.yaml", scheme, ctrl.Log.WithName("OperatorManager"), pspName)
+	opMgr, err := operatormanager.New(ctrlPlaneClusterMgr.GetClient(), svcClusterConf, "external/svc-postgres-operator.yaml", scheme, ctrl.Log.WithName("OperatorManager"), pspName)
 	if err != nil {
 		setupLog.Error(err, "unable to create `OperatorManager`")
 		os.Exit(1)
@@ -165,7 +165,7 @@ func main() {
 	ctx := context.Background()
 
 	// update all existing operators to the current version
-	if err := opMgr.UpdateAllOperators(ctx); err != nil {
+	if err := opMgr.UpdateAllZalandoOperators(ctx); err != nil {
 		setupLog.Error(err, "error updating the postgres operators")
 	}
 


### PR DESCRIPTION
So that we can later migrate to idiomatic `controllerutil.CreateOrUpdate` or even `controllerutil.CreateOrPatch`. Moreover, the logic related to the extended opeartor (zalando operator + *pod environment configmap* + *sidecars configmap*) is all shifted to `OperatorManager`, not mixed in `PostgresController` anymore.