### PR TITLE
Switch from UID to Name when creating Zalando postgres resources

### DIFF
--- a/api/v1/postgres_types.go
+++ b/api/v1/postgres_types.go
@@ -369,7 +369,7 @@ func (p *Postgres) generateTeamID() string {
 
 func (p *Postgres) generateDatabaseName() string {
 	// We only want letters and numbers
-	generatedDatabaseName := alphaNumericRegExp.ReplaceAllString(string(p.UID), "")
+	generatedDatabaseName := alphaNumericRegExp.ReplaceAllString(string(p.Name), "")
 
 	// Limit size
 	maxLen := 20


### PR DESCRIPTION
 * Use the `Name` of the custom fits postgres resource in the postgres cluster name instead of the `UID` (so that it matches the IDs schon in `cloudctl postgres ls`) 