### PR TITLE
Ignore NotFound errors when deleting the passwords secret in the reconcile loop

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -42,7 +42,7 @@ import (
 const (
 	// duration = time.Second * 10
 	interval = time.Second * 2
-	timeout  = time.Second * 30
+	timeout  = time.Second * 60
 )
 
 var (


### PR DESCRIPTION
Stupid error.

Once the passwords secret was successfully removed, subsequent runs of he reconcile loop fail as trying to remove the (already removed) secret fails. 