### PR TITLE
Add annotations for tenant and projectID to service

### DIFF
--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -63,6 +63,8 @@ type PostgresReconciler struct {
 	recorder                    record.EventRecorder
 	PgParamBlockList            map[string]bool
 	StandbyClustersSourceRanges []string
+	PostgresletNamespace        string
+	SidecarsConfigMapName       string
 }
 
 // Reconcile is the entry point for postgres reconciliation.
@@ -200,9 +202,8 @@ func (r *PostgresReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	// try to fetch the global sidecars configmap
 	cns := types.NamespacedName{
-		// TODO don't use string literals here! name is dependent of the release name of the helm chart!
-		Namespace: "postgreslet-system",
-		Name:      "postgreslet-postgres-sidecars",
+		Namespace: r.PostgresletNamespace,
+		Name:      r.SidecarsConfigMapName,
 	}
 	globalSidecarsCM := &corev1.ConfigMap{}
 	if err := r.SvcClient.Get(ctx, cns, globalSidecarsCM); err != nil {

--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -42,8 +42,8 @@ import (
 const (
 	postgresExporterServiceName                    string = "postgres-exporter"
 	postgresExporterServicePortName                string = "metrics"
-	postgresExporterServiceTenantAnnotationName    string = "cs.fits.cloud/tenant"
-	postgresExporterServiceProjectIDAnnotationName string = "cs.fits.cloud/project-id"
+	postgresExporterServiceTenantAnnotationName    string = pg.TenantLabelName
+	postgresExporterServiceProjectIDAnnotationName string = pg.ProjectIDLabelName
 )
 
 // requeue defines in how many seconds a requeue should happen

--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -210,13 +210,13 @@ func (r *PostgresReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, fmt.Errorf("could not fetch config for sidecars")
 	}
 	// Add services for our sidecars
-	namespace := req.NamespacedName
-	if err := r.createOrUpdateExporterSidecarServices(ctx, namespace.Namespace, sidecarCM); err != nil {
+	namespace := instance.ToPeripheralResourceNamespace()
+	if err := r.createOrUpdateExporterSidecarServices(ctx, namespace, sidecarCM); err != nil {
 		return ctrl.Result{}, fmt.Errorf("error while creating sidecars services %v: %w", namespace, err)
 	}
 
 	// Add service monitor for our exporter sidecar
-	err := r.createOrUpdateExporterSidecarServiceMonitor(ctx, namespace.Name, instance)
+	err := r.createOrUpdateExporterSidecarServiceMonitor(ctx, namespace, instance)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("error while creating sidecars servicemonitor %v: %w", namespace, err)
 	}

--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -204,14 +204,14 @@ func (r *PostgresReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		Namespace: "postgreslet-system",
 		Name:      "postgreslet-postgres-sidecars",
 	}
-	sidecarsCM := &corev1.ConfigMap{}
-	if err := r.SvcClient.Get(ctx, cns, sidecarsCM); err != nil {
+	globalSidecarsCM := &corev1.ConfigMap{}
+	if err := r.SvcClient.Get(ctx, cns, globalSidecarsCM); err != nil {
 		// configmap with configuration does not exists, nothing we can do here...
 		return ctrl.Result{}, fmt.Errorf("could not fetch config for sidecars")
 	}
 	// Add services for our sidecars
 	namespace := instance.ToPeripheralResourceNamespace()
-	if err := r.createOrUpdateExporterSidecarServices(ctx, namespace, sidecarsCM, instance); err != nil {
+	if err := r.createOrUpdateExporterSidecarServices(ctx, namespace, globalSidecarsCM, instance); err != nil {
 		return ctrl.Result{}, fmt.Errorf("error while creating sidecars services %v: %w", namespace, err)
 	}
 
@@ -221,7 +221,7 @@ func (r *PostgresReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, fmt.Errorf("error while creating sidecars servicemonitor %v: %w", namespace, err)
 	}
 
-	if err := r.createOrUpdateZalandoPostgresql(ctx, instance, log, sidecarsCM); err != nil {
+	if err := r.createOrUpdateZalandoPostgresql(ctx, instance, log, globalSidecarsCM); err != nil {
 		r.recorder.Eventf(instance, "Warning", "Error", "failed to create Zalando resource: %v", err)
 		return ctrl.Result{}, fmt.Errorf("failed to create or update zalando postgresql: %w", err)
 	}

--- a/pkg/operatormanager/operatormanager.go
+++ b/pkg/operatormanager/operatormanager.go
@@ -60,6 +60,8 @@ type Options struct {
 	EtcdHost                string
 	CRDValidation           bool
 	MajorVersionUpgradeMode string
+	PostgresletNamespace    string
+	SidecarsConfigMapName   string
 }
 
 // OperatorManager manages the operator
@@ -487,9 +489,8 @@ func (m *OperatorManager) createPodEnvironmentConfigMap(ctx context.Context, nam
 func (m *OperatorManager) createOrUpdateSidecarsConfig(ctx context.Context, namespace string) error {
 	// try to fetch the global sidecars configmap
 	cns := types.NamespacedName{
-		// TODO don't use string literals here! name is dependent of the release name of the helm chart!
-		Namespace: "postgreslet-system",
-		Name:      "postgreslet-postgres-sidecars",
+		Namespace: m.options.PostgresletNamespace,
+		Name:      m.options.SidecarsConfigMapName,
 	}
 	globalSidecarsCM := &corev1.ConfigMap{}
 	if err := m.Get(ctx, cns, globalSidecarsCM); err != nil {

--- a/pkg/operatormanager/operatormanager.go
+++ b/pkg/operatormanager/operatormanager.go
@@ -491,15 +491,15 @@ func (m *OperatorManager) createOrUpdateSidecarsConfig(ctx context.Context, name
 		Namespace: "postgreslet-system",
 		Name:      "postgreslet-postgres-sidecars",
 	}
-	c := &corev1.ConfigMap{}
-	if err := m.Get(ctx, cns, c); err != nil {
+	sidecarsCM := &corev1.ConfigMap{}
+	if err := m.Get(ctx, cns, sidecarsCM); err != nil {
 		// configmap with configuration does not exists, nothing we can do here...
 		m.log.Error(err, "could not fetch config for sidecars")
 		return err
 	}
 
 	// Add our sidecars configmap
-	if err := m.createOrUpdateSidecarsConfigMap(ctx, namespace, c); err != nil {
+	if err := m.createOrUpdateSidecarsConfigMap(ctx, namespace, sidecarsCM); err != nil {
 		return fmt.Errorf("error while creating sidecars configmap %v: %w", namespace, err)
 	}
 

--- a/pkg/operatormanager/operatormanager.go
+++ b/pkg/operatormanager/operatormanager.go
@@ -506,6 +506,7 @@ func (m *OperatorManager) createOrUpdateSidecarsConfig(ctx context.Context, name
 	return nil
 }
 
+// createOrUpdateSidecarsConfigMap Creates/updates a local ConfigMap for the sidecars, which e.g. contains the config files to mount in the sidecars
 func (m *OperatorManager) createOrUpdateSidecarsConfigMap(ctx context.Context, namespace string, globalSidecarsCM *corev1.ConfigMap) error {
 	sccm := &corev1.ConfigMap{}
 	if err := m.SetName(sccm, localSidecarsCMName); err != nil {


### PR DESCRIPTION
* Move the creation/update/deletion of the sidecars service from the operator manager to the postgres controller
* Add postgres-specific tenant and projectID annotations to the service (and service monitor)
* Make the name of the global sidecars configmap configurable