### PR TITLE
Remove clone block

### DIFF
--- a/api/v1/postgres_types.go
+++ b/api/v1/postgres_types.go
@@ -577,6 +577,9 @@ func (p *Postgres) ToUnstructuredZalandoPostgresql(z *zalando.Postgresql, c *cor
 			S3SecretAccessKey: rbs.S3SecretKey,
 			S3ForcePathStyle:  pointer.Bool(true),
 		}
+	} else {
+		// if we don't set the clone block, remove it completely
+		z.Spec.Clone = nil
 	}
 
 	// Enable replication (using unstructured json)


### PR DESCRIPTION
When calling `cloudctl postgres restore-accepted`, the `clone` Block ist not being removed properly. This PR intends to fix that.