### PR TITLE
Broaden selector for leader pod to fix issues with new spilo image

### DIFF
--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -699,7 +699,11 @@ func (r *PostgresReconciler) updatePatroniConfig(ctx context.Context, instance *
 	r.Log.Info("Sending REST call to Patroni API")
 	pods := &corev1.PodList{}
 
-	roleReq, _ := labels.NewRequirement("spilo-role", selection.In, []string{"master", "standby_leader"})
+	roleReq, err := labels.NewRequirement("spilo-role", selection.In, []string{"master", "standby_leader"})
+	if err != nil {
+		r.Log.Info("could not create requirements for label selector to query pods, requeuing")
+		return err
+	}
 	leaderSelector := labels.NewSelector()
 	leaderSelector = leaderSelector.Add(*roleReq)
 


### PR DESCRIPTION
While testing a new spilo image, the `promote-to-primary` command failed because no `master` pod was found. On further analysis, the role now seems to be `standby_leader`.

To keep it generic, we switched the selector:

From the equivalent of 
```
kubectl get po -l spilo-role=master
```
to the equivalent of
```
kubectl get po -l "spilo-role in (master,standby_leader)"
```

This should now select the Leader and the Standby Leader Pods when calling the Patroni REST API.