### PR TITLE
Update svc to new spilo role

### DIFF
--- a/api/v1/postgres_types.go
+++ b/api/v1/postgres_types.go
@@ -319,7 +319,7 @@ func (p *Postgres) ToKey() *types.NamespacedName {
 	}
 }
 
-func (p *Postgres) ToSvcLB(lbIP string, lbPort int32) *corev1.Service {
+func (p *Postgres) ToSvcLB(lbIP string, lbPort int32, enableStandbyLeaderSelector bool) *corev1.Service {
 	lb := &corev1.Service{}
 	lb.Spec.Type = "LoadBalancer"
 
@@ -341,7 +341,7 @@ func (p *Postgres) ToSvcLB(lbIP string, lbPort int32) *corev1.Service {
 	lb.Spec.Ports = []corev1.ServicePort{port}
 
 	spiloRole := SpiloRoleLabelValueMaster
-	if !p.IsReplicationPrimary() {
+	if enableStandbyLeaderSelector && !p.IsReplicationPrimary() {
 		spiloRole = SpiloRoleLabelValueStandbyLeader
 	}
 	lb.Spec.Selector = map[string]string{

--- a/api/v1/postgres_types.go
+++ b/api/v1/postgres_types.go
@@ -61,6 +61,12 @@ const (
 	StandbyKey    = "standby"
 	StandbyMethod = "streaming_host"
 
+	ApplicationLabelName             = "application"
+	ApplicationLabelValue            = "spilo"
+	SpiloRoleLabelName               = "spilo-role"
+	SpiloRoleLabelValueMaster        = "master"
+	SpiloRoleLabelValueStandbyLeader = "standby_leader"
+
 	teamIDPrefix = "pg"
 
 	DefaultPatroniParamValueLoopWait     uint32 = 10
@@ -334,15 +340,15 @@ func (p *Postgres) ToSvcLB(lbIP string, lbPort int32) *corev1.Service {
 	port.TargetPort = intstr.FromInt(5432)
 	lb.Spec.Ports = []corev1.ServicePort{port}
 
-	spiloRole := "master"
+	spiloRole := SpiloRoleLabelValueMaster
 	if !p.IsReplicationPrimary() {
-		spiloRole = "standby_leader"
+		spiloRole = SpiloRoleLabelValueStandbyLeader
 	}
 	lb.Spec.Selector = map[string]string{
-		"application":  "spilo",
-		"cluster-name": p.ToPeripheralResourceName(),
-		"spilo-role":   spiloRole,
-		"team":         p.generateTeamID(),
+		ApplicationLabelName: ApplicationLabelValue,
+		"cluster-name":       p.ToPeripheralResourceName(),
+		SpiloRoleLabelName:   spiloRole,
+		"team":               p.generateTeamID(),
 	}
 
 	if len(lbIP) > 0 {
@@ -408,9 +414,9 @@ func (p *Postgres) ToUserPasswordsSecretListOption() []client.ListOption {
 
 func (p *Postgres) ToUserPasswordSecretMatchingLabels() map[string]string {
 	return map[string]string{
-		"application":  "spilo",
-		"cluster-name": p.ToPeripheralResourceName(),
-		"team":         p.generateTeamID(),
+		ApplicationLabelName: ApplicationLabelValue,
+		"cluster-name":       p.ToPeripheralResourceName(),
+		"team":               p.generateTeamID(),
 	}
 }
 

--- a/api/v1/postgres_types.go
+++ b/api/v1/postgres_types.go
@@ -334,10 +334,14 @@ func (p *Postgres) ToSvcLB(lbIP string, lbPort int32) *corev1.Service {
 	port.TargetPort = intstr.FromInt(5432)
 	lb.Spec.Ports = []corev1.ServicePort{port}
 
+	spiloRole := "master"
+	if !p.IsReplicationPrimary() {
+		spiloRole = "standby_leader"
+	}
 	lb.Spec.Selector = map[string]string{
 		"application":  "spilo",
 		"cluster-name": p.ToPeripheralResourceName(),
-		"spilo-role":   "master",
+		"spilo-role":   spiloRole,
 		"team":         p.generateTeamID(),
 	}
 

--- a/pkg/lbmanager/lbmanager.go
+++ b/pkg/lbmanager/lbmanager.go
@@ -66,9 +66,9 @@ func (m *LBManager) CreateSvcLBIfNone(ctx context.Context, in *api.Postgres) err
 
 	// update the selector, and only the selector (we do NOT want the change the ip or port here!!!)
 	if in.IsReplicationPrimary() {
-		svc.Spec.Selector["spilo-role"] = "master"
+		svc.Spec.Selector[api.SpiloRoleLabelName] = api.SpiloRoleLabelValueMaster
 	} else {
-		svc.Spec.Selector["spilo-role"] = "standby_leader"
+		svc.Spec.Selector[api.SpiloRoleLabelName] = api.SpiloRoleLabelValueStandbyLeader
 	}
 	if err := m.Update(ctx, svc); err != nil {
 		return fmt.Errorf("failed to update Service of type LoadBalancer: %w", err)

--- a/pkg/operatormanager/operatormanager.go
+++ b/pkg/operatormanager/operatormanager.go
@@ -578,7 +578,7 @@ func (m *OperatorManager) deletePodEnvironmentConfigMap(ctx context.Context, nam
 
 // toInstanceMatchingLabels makes the matching labels for the pods of the instances operated by the operator
 func (m *OperatorManager) toInstanceMatchingLabels() *client.MatchingLabels {
-	return &client.MatchingLabels{"application": "spilo"}
+	return &client.MatchingLabels{pg.ApplicationLabelName: pg.ApplicationLabelValue}
 }
 
 // toObjectKey makes ObjectKey from namespace and the name of obj


### PR DESCRIPTION
With the new spilo image, standby leaders use a different `spilo-role` (`standby_leader` instead of the previous `master`), which totally makes sense but breaks our pod selector in the `Service` we create.

As a solution, the `lbmanager` now updates the selector based on the replication status of the instance.