### PR TITLE
PoC of new sidecars definition

### DIFF
--- a/api/v1/postgres_types.go
+++ b/api/v1/postgres_types.go
@@ -731,6 +731,9 @@ func (p *Postgres) buildSidecars(c *corev1.ConfigMap) []zalando.Sidecar {
 		}
 	}
 
+	// TODO only use envs here, leave the rest to the postgres-operator configmap?
+	// TODO also set PG_EXPORTER_CONSTANT_LABELS with partitionid and postgres cluster name
+
 	return sidecars
 }
 

--- a/pkg/operatormanager/operatormanager.go
+++ b/pkg/operatormanager/operatormanager.go
@@ -73,7 +73,8 @@ type OperatorManager struct {
 	log  logr.Logger
 	meta.MetadataAccessor
 	*runtime.Scheme
-	options Options
+	options          Options
+	globalSidecarsCM *corev1.ConfigMap
 }
 
 // New creates a new `OperatorManager`
@@ -415,6 +416,11 @@ func (m *OperatorManager) editConfigMap(cm *corev1.ConfigMap, namespace string, 
 	cm.Data["replication_username"] = "standby"
 
 	cm.Data["enable_pod_antiaffinity"] = strconv.FormatBool(options.PodAntiaffinity)
+
+	if sidecarsCM, err := m.getSidecarsCM(); err == nil && sidecarsCM != nil {
+		cm.Data["sidecars"] = sidecarsCM.Data["sidecars"]
+	}
+
 }
 
 // ensureCleanMetadata ensures obj has clean metadata
@@ -617,4 +623,23 @@ func (m *OperatorManager) UpdateAllOperators(ctx context.Context) error {
 
 	m.log.Info("Done updating postgres operators in managed namespaces")
 	return nil
+}
+
+func (m *OperatorManager) getSidecarsCM() (*corev1.ConfigMap, error) {
+	// return cached version
+	if m.globalSidecarsCM != nil {
+		return m.globalSidecarsCM, nil
+	}
+
+	// try to fetch the global sidecars configmap
+	cns := types.NamespacedName{
+		Namespace: m.options.PostgresletNamespace,
+		Name:      m.options.SidecarsConfigMapName,
+	}
+	m.globalSidecarsCM = &corev1.ConfigMap{}
+	if err := m.Get(context.Background(), cns, m.globalSidecarsCM); err != nil {
+		// configmap with configuration does not exists, nothing we can do here...
+		return nil, fmt.Errorf("could not fetch config for sidecars")
+	}
+	return m.globalSidecarsCM, nil
 }


### PR DESCRIPTION
to allow setting the `securityContext` for sidecars, we need to move the definition of those sidecars from the `postgresql` custom ressource to the operators configmap.