### PR TITLE
Relax clone block creation

### DIFF
--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -307,17 +307,17 @@ func (r *PostgresReconciler) createOrUpdateZalandoPostgresql(ctx context.Context
 		src := &pg.Postgres{}
 		if err := r.CtrlClient.Get(ctx, srcNs, src); err != nil {
 			r.recorder.Eventf(instance, "Warning", "Error", "failed to get source postgres for restore: %v", err)
-			return err
-		}
-		log.Info("source for restore fetched", "postgres", instance)
+		} else {
+			log.Info("source for restore fetched", "postgres", instance)
 
-		bc, err := r.getBackupConfig(ctx, instance.Namespace, src.Spec.BackupSecretRef)
-		if err != nil {
-			return err
-		}
+			bc, err := r.getBackupConfig(ctx, instance.Namespace, src.Spec.BackupSecretRef)
+			if err != nil {
+				return err
+			}
 
-		restoreBackupConfig = bc
-		restoreSouceInstance = src
+			restoreBackupConfig = bc
+			restoreSouceInstance = src
+		}
 	}
 
 	// Get zalando postgresql and create one if none.

--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -306,7 +306,7 @@ func (r *PostgresReconciler) createOrUpdateZalandoPostgresql(ctx context.Context
 		}
 		src := &pg.Postgres{}
 		if err := r.CtrlClient.Get(ctx, srcNs, src); err != nil {
-			r.recorder.Eventf(instance, "Warning", "Error", "failed to get resource: %v", err)
+			r.recorder.Eventf(instance, "Warning", "Error", "failed to get source postgres for restore: %v", err)
 			return err
 		}
 		log.Info("source for restore fetched", "postgres", instance)


### PR DESCRIPTION
When a restore is requested, we use the referenced source database to retrieve the S3 credentials required for the `clone` Block.

If that source database was already deleted, but for some reason that database is still referenced (e.g. the restore was not completed by calling `cloudctl postgres restore-accepted`), we cannot fetch the required information anymore.

This PR changes the behaviour in such a case: we simply ignore that referenced (but non-existing) source database and thus skip the creation of the `clone` block (instead of aborting the creation/update of the `postgresql` custom resource altogether).