### PR TITLE
Use api url from annotation

### DIFF
--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -747,7 +747,7 @@ func (r *PostgresReconciler) checkAndUpdatePatroniReplicationConfig(ctx context.
 			return requeueImmediately, r.httpPatchPatroni(ctx, instance, leaderIP)
 		}
 		if instance.Spec.PostgresConnection.SynchronousReplication {
-			if *resp.SynchronousNodesAdditional != instance.Spec.PostgresConnection.ConnectedPostgresID {
+			if resp.SynchronousNodesAdditional == nil || *resp.SynchronousNodesAdditional != instance.Spec.PostgresConnection.ConnectedPostgresID {
 				r.Log.Info("synchronous_nodes_additional mistmatch, updating and requeing", "response", resp)
 				return requeueImmediately, r.httpPatchPatroni(ctx, instance, leaderIP)
 			}

--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -18,6 +18,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 	zalando "github.com/zalando/postgres-operator/pkg/apis/acid.zalan.do/v1"
@@ -227,7 +228,7 @@ func (r *PostgresReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	if immediateRequeue {
 		// if a config change was performed that requires a while to settle in, we simply requeue
 		// on the next reconciliation loop, the config should be correct already so we can continue with the rest
-		return requeue, patroniErr
+		return ctrl.Result{Requeue: true, RequeueAfter: 10 * time.Second}, patroniErr
 	}
 
 	// create standby egress rule first, so the standby can actually connect to the primary

--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -751,26 +751,33 @@ func (r *PostgresReconciler) checkAndUpdatePatroniReplicationConfig(ctx context.
 		}
 	} else {
 		if resp.StandbyCluster == nil {
+			r.Log.Info("updating and requeing, got %v", resp)
 			return requeueImmediately, r.httpPatchPatroni(ctx, instance, leaderIP)
 		}
 		if resp.StandbyCluster.CreateReplicaMethods == nil {
 			// TODO check for actual content instead of nil
+			r.Log.Info("updating and requeing, got %v", resp)
 			return requeueImmediately, r.httpPatchPatroni(ctx, instance, leaderIP)
 		}
 		if resp.StandbyCluster.Host != instance.Spec.PostgresConnection.ConnectionIP {
+			r.Log.Info("updating and requeing, got %v", resp)
 			return requeueImmediately, r.httpPatchPatroni(ctx, instance, leaderIP)
 		}
 		if resp.StandbyCluster.Port != int(instance.Spec.PostgresConnection.ConnectionPort) {
+			r.Log.Info("updating and requeing, got %v", resp)
 			return requeueImmediately, r.httpPatchPatroni(ctx, instance, leaderIP)
 		}
 		if resp.StandbyCluster.ApplicationName != instance.ObjectMeta.Name {
+			r.Log.Info("updating and requeing, got %v", resp)
 			return requeueImmediately, r.httpPatchPatroni(ctx, instance, leaderIP)
 		}
 
 		if resp.SynchronousNodesAdditional == nil {
+			r.Log.Info("updating and requeing, got %v", resp)
 			return requeueImmediately, r.httpPatchPatroni(ctx, instance, leaderIP)
 		}
 		if resp.SynchronousNodesAdditional != pointer.String(instance.Spec.PostgresConnection.ConnectedPostgresID) {
+			r.Log.Info("updating and requeing, got %v", resp)
 			return requeueImmediately, r.httpPatchPatroni(ctx, instance, leaderIP)
 		}
 	}

--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -737,7 +737,7 @@ func (r *PostgresReconciler) checkAndUpdatePatroniReplicationConfig(ctx context.
 	leaderIP := leaderPods.Items[0].Status.PodIP
 
 	var resp *PatroniConfigRequest
-	resp, err = r.httpGetPatroniConfig(ctx, instance, leaderIP)
+	resp, err = r.httpGetPatroniConfig(ctx, leaderIP)
 	if err != nil {
 		return continueWithReconciliation, err
 	}
@@ -865,7 +865,7 @@ func (r *PostgresReconciler) httpPatchPatroni(ctx context.Context, instance *pg.
 	return nil
 }
 
-func (r *PostgresReconciler) httpGetPatroniConfig(ctx context.Context, instance *pg.Postgres, podIP string) (*PatroniConfigRequest, error) {
+func (r *PostgresReconciler) httpGetPatroniConfig(ctx context.Context, podIP string) (*PatroniConfigRequest, error) {
 	if podIP == "" {
 		return nil, errors.New("podIP must not be empty")
 	}

--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -751,33 +751,33 @@ func (r *PostgresReconciler) checkAndUpdatePatroniReplicationConfig(ctx context.
 		}
 	} else {
 		if resp.StandbyCluster == nil {
-			r.Log.Info("updating and requeing, got %v", resp)
+			r.Log.Info("updating and requeing", "response", resp)
 			return requeueImmediately, r.httpPatchPatroni(ctx, instance, leaderIP)
 		}
 		if resp.StandbyCluster.CreateReplicaMethods == nil {
 			// TODO check for actual content instead of nil
-			r.Log.Info("updating and requeing, got %v", resp)
+			r.Log.Info("updating and requeing", "response", resp)
 			return requeueImmediately, r.httpPatchPatroni(ctx, instance, leaderIP)
 		}
 		if resp.StandbyCluster.Host != instance.Spec.PostgresConnection.ConnectionIP {
-			r.Log.Info("updating and requeing, got %v", resp)
+			r.Log.Info("updating and requeing", "response", resp)
 			return requeueImmediately, r.httpPatchPatroni(ctx, instance, leaderIP)
 		}
 		if resp.StandbyCluster.Port != int(instance.Spec.PostgresConnection.ConnectionPort) {
-			r.Log.Info("updating and requeing, got %v", resp)
+			r.Log.Info("updating and requeing", "response", resp)
 			return requeueImmediately, r.httpPatchPatroni(ctx, instance, leaderIP)
 		}
 		if resp.StandbyCluster.ApplicationName != instance.ObjectMeta.Name {
-			r.Log.Info("updating and requeing, got %v", resp)
+			r.Log.Info("updating and requeing", "response", resp)
 			return requeueImmediately, r.httpPatchPatroni(ctx, instance, leaderIP)
 		}
 
 		if resp.SynchronousNodesAdditional == nil {
-			r.Log.Info("updating and requeing, got %v", resp)
+			r.Log.Info("updating and requeing", "response", resp)
 			return requeueImmediately, r.httpPatchPatroni(ctx, instance, leaderIP)
 		}
 		if resp.SynchronousNodesAdditional != pointer.String(instance.Spec.PostgresConnection.ConnectedPostgresID) {
-			r.Log.Info("updating and requeing, got %v", resp)
+			r.Log.Info("updating and requeing", "response", resp)
 			return requeueImmediately, r.httpPatchPatroni(ctx, instance, leaderIP)
 		}
 	}

--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -876,7 +876,7 @@ func (r *PostgresReconciler) httpGetPatroniConfig(ctx context.Context, instance 
 	httpClient := &http.Client{}
 	url := "http://" + podIP + ":" + podPort + "/" + path
 
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		r.Log.Error(err, "could not create request")
 		return nil, err

--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -224,16 +224,12 @@ func (r *PostgresReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 
 	// check (and update if neccessary) the current patroni replication config.
-	var patroniErr error
-	// for primary databases, do that call before updating the custom ressource
-	if instance.IsReplicationPrimary() {
-		immediateRequeue, patroniErr := r.checkAndUpdatePatroniReplicationConfig(ctx, instance)
-		if immediateRequeue {
-			// if a config change was performed that requires a while to settle in, we simply requeue
-			// on the next reconciliation loop, the config should be correct already so we can continue with the rest
-			log.Info("Requeueing after patroni replication config change")
-			return ctrl.Result{Requeue: true, RequeueAfter: 10 * time.Second}, patroniErr
-		}
+	immediateRequeue, patroniErr := r.checkAndUpdatePatroniReplicationConfig(ctx, instance)
+	if immediateRequeue {
+		// if a config change was performed that requires a while to settle in, we simply requeue
+		// on the next reconciliation loop, the config should be correct already so we can continue with the rest
+		log.Info("Requeueing after patroni replication config change")
+		return ctrl.Result{Requeue: true, RequeueAfter: 10 * time.Second}, patroniErr
 	}
 
 	// create standby egress rule first, so the standby can actually connect to the primary
@@ -286,17 +282,6 @@ func (r *PostgresReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	if err := r.createOrUpdateIngressCWNP(ctx, instance, int(port)); err != nil {
 		r.recorder.Event(instance, "Warning", "Error", "failed to create or update ingress ClusterwideNetworkPolicy")
 		return ctrl.Result{}, fmt.Errorf("unable to create or update ingress ClusterwideNetworkPolicy: %w", err)
-	}
-
-	// for standby databases, do that call after updating the custom ressource
-	if !instance.IsReplicationPrimary() {
-		immediateRequeue, patroniErr := r.checkAndUpdatePatroniReplicationConfig(ctx, instance)
-		if immediateRequeue {
-			// if a config change was performed that requires a while to settle in, we simply requeue
-			// on the next reconciliation loop, the config should be correct already so we can continue with the rest
-			log.Info("Requeueing after patroni replication config change")
-			return ctrl.Result{Requeue: true, RequeueAfter: 10 * time.Second}, patroniErr
-		}
 	}
 
 	// when an error occurred while updating the patroni config, requeue here
@@ -801,7 +786,6 @@ func (r *PostgresReconciler) checkAndUpdatePatroniReplicationConfig(ctx context.
 		}
 	}
 
-	r.Log.Info("replication config from Patroni API up to date")
 	return continueWithReconciliation, nil
 }
 

--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -90,6 +90,7 @@ type PatroniConfigRequest struct {
 }
 
 // Reconcile is the entry point for postgres reconciliation.
+// +kubebuilder:rbac:groups=database.fits.cloud,resources=postgres,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=database.fits.cloud,resources=postgres/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=acid.zalan.do,resources=postgresqls,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=acid.zalan.do,resources=postgresqls/status,verbs=get;list;watch

--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -67,16 +67,17 @@ type PostgresReconciler struct {
 	PartitionID, Tenant, StorageClass string
 	*operatormanager.OperatorManager
 	*lbmanager.LBManager
-	recorder                    record.EventRecorder
-	PgParamBlockList            map[string]bool
-	StandbyClustersSourceRanges []string
-	PostgresletNamespace        string
-	SidecarsConfigMapName       string
-	EnableNetPol                bool
-	EtcdHost                    string
-	PatroniTTL                  uint32
-	PatroniLoopWait             uint32
-	PatroniRetryTimeout         uint32
+	recorder                         record.EventRecorder
+	PgParamBlockList                 map[string]bool
+	StandbyClustersSourceRanges      []string
+	PostgresletNamespace             string
+	SidecarsConfigMapName            string
+	EnableNetPol                     bool
+	EtcdHost                         string
+	PatroniTTL                       uint32
+	PatroniLoopWait                  uint32
+	PatroniRetryTimeout              uint32
+	ReplicationChangeRequeueDuration time.Duration
 }
 
 type PatroniStandbyCluster struct {
@@ -229,7 +230,7 @@ func (r *PostgresReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		// if a config change was performed that requires a while to settle in, we simply requeue
 		// on the next reconciliation loop, the config should be correct already so we can continue with the rest
 		log.Info("Requeueing after patroni replication config change")
-		return ctrl.Result{Requeue: true, RequeueAfter: 10 * time.Second}, patroniErr
+		return ctrl.Result{Requeue: true, RequeueAfter: r.ReplicationChangeRequeueDuration}, patroniErr
 	}
 
 	// create standby egress rule first, so the standby can actually connect to the primary

--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -932,6 +932,8 @@ func (r *PostgresReconciler) httpGetPatroniConfig(ctx context.Context, podIP str
 		return nil, err
 	}
 
+	r.Log.Info("Got config", "response", jsonResp)
+
 	return &jsonResp, err
 }
 

--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -743,45 +743,45 @@ func (r *PostgresReconciler) checkAndUpdatePatroniReplicationConfig(ctx context.
 
 	if instance.IsReplicationPrimary() {
 		if resp.StandbyCluster != nil {
+			r.Log.Info("standby_cluster mistmatch, updating and requeing", "response", resp)
 			return requeueImmediately, r.httpPatchPatroni(ctx, instance, leaderIP)
 		}
 		if instance.Spec.PostgresConnection.SynchronousReplication {
-			// enable sync replication
-			if resp.SynchronousNodesAdditional != pointer.String(instance.Spec.PostgresConnection.ConnectedPostgresID) {
+			if *resp.SynchronousNodesAdditional != instance.Spec.PostgresConnection.ConnectedPostgresID {
+				r.Log.Info("synchronous_nodes_additional mistmatch, updating and requeing", "response", resp)
 				return requeueImmediately, r.httpPatchPatroni(ctx, instance, leaderIP)
 			}
 		} else {
-			// disable sync replication
 			if resp.SynchronousNodesAdditional != nil {
+				r.Log.Info("synchronous_nodes_additional mistmatch, updating and requeing", "response", resp)
 				return requeueImmediately, r.httpPatchPatroni(ctx, instance, leaderIP)
 			}
 		}
 
 	} else {
 		if resp.StandbyCluster == nil {
-			r.Log.Info("updating and requeing", "response", resp)
+			r.Log.Info("standby_cluster mismatch, updating and requeing", "response", resp)
 			return requeueImmediately, r.httpPatchPatroni(ctx, instance, leaderIP)
 		}
 		if resp.StandbyCluster.CreateReplicaMethods == nil {
-			// TODO check for actual content instead of nil
-			r.Log.Info("updating and requeing", "response", resp)
+			r.Log.Info("create_replica_methods mismatch, updating and requeing", "response", resp)
 			return requeueImmediately, r.httpPatchPatroni(ctx, instance, leaderIP)
 		}
 		if resp.StandbyCluster.Host != instance.Spec.PostgresConnection.ConnectionIP {
-			r.Log.Info("updating and requeing", "response", resp)
+			r.Log.Info("host mismatch, updating and requeing", "response", resp)
 			return requeueImmediately, r.httpPatchPatroni(ctx, instance, leaderIP)
 		}
 		if resp.StandbyCluster.Port != int(instance.Spec.PostgresConnection.ConnectionPort) {
-			r.Log.Info("updating and requeing", "response", resp)
+			r.Log.Info("port mismatch, updating and requeing", "response", resp)
 			return requeueImmediately, r.httpPatchPatroni(ctx, instance, leaderIP)
 		}
 		if resp.StandbyCluster.ApplicationName != instance.ObjectMeta.Name {
-			r.Log.Info("updating and requeing", "response", resp)
+			r.Log.Info("application_name mismatch, updating and requeing", "response", resp)
 			return requeueImmediately, r.httpPatchPatroni(ctx, instance, leaderIP)
 		}
 
 		if resp.SynchronousNodesAdditional != nil {
-			r.Log.Info("updating and requeing", "response", resp)
+			r.Log.Info("synchronous_nodes_additional mistmatch, updating and requeing", "response", resp)
 			return requeueImmediately, r.httpPatchPatroni(ctx, instance, leaderIP)
 		}
 	}

--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -786,6 +786,7 @@ func (r *PostgresReconciler) checkAndUpdatePatroniReplicationConfig(ctx context.
 		}
 	}
 
+	r.Log.Info("replication config from Patroni API up to date")
 	return continueWithReconciliation, nil
 }
 


### PR DESCRIPTION
Based on #423 

The pod contains a `status` annotation, which contains a JSON object with an `api_url` field. This PR uses that value instead of guessing the API (which we still do as a fallback)