### PR TITLE
Create postgres-pod-config when missing

### DIFF
--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -391,7 +391,7 @@ func (r *PostgresReconciler) ensureZalandoDependencies(ctx context.Context, p *p
 }
 
 func (r *PostgresReconciler) updatePodEnvironmentConfigMap(ctx context.Context, p *pg.Postgres) error {
-	log := r.Log.WithValues("postgres", p.UID)
+	log := r.Log.WithValues("namespace", p.Namespace)
 	if p.Spec.BackupSecretRef == "" {
 		log.Info("No configured backupSecretRef found, skipping configuration of postgres backup")
 		return nil

--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -465,7 +465,7 @@ func (r *PostgresReconciler) updatePodEnvironmentConfigMap(ctx context.Context, 
 		if err := r.CreatePodEnvironmentConfigMap(ctx, ns.Namespace); err != nil {
 			return fmt.Errorf("error while creating the missing Pod Environment ConfigMap %v: %w", ns.Namespace, err)
 		}
-		return fmt.Errorf("mising Pod Environment ConfigMap created, requeueing: %w", err)
+		log.Info("mising Pod Environment ConfigMap created!")
 	}
 	cm.Data = data
 	if err := r.SvcClient.Update(ctx, cm); err != nil {

--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -462,8 +462,8 @@ func (r *PostgresReconciler) updatePodEnvironmentConfigMap(ctx context.Context, 
 		// operatormanager.OperatorManager.UpdateAllManagedOperators does not call InstallOrUpdateOperator)
 		// we previously aborted here (before the postgresql resource was updated with the new labels), meaning we would
 		// simply restart the loop without solving the problem.
-		if err := r.SvcClient.Create(ctx, cm); err != nil {
-			return fmt.Errorf("error while creating the missing Pod Environment ConfigMap: %w", err)
+		if err := r.CreatePodEnvironmentConfigMap(ctx, ns.Namespace); err != nil {
+			return fmt.Errorf("error while creating the missing Pod Environment ConfigMap %v: %w", ns.Namespace, err)
 		}
 		log.Info("mising Pod Environment ConfigMap created!")
 	}

--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -457,7 +457,15 @@ func (r *PostgresReconciler) updatePodEnvironmentConfigMap(ctx context.Context, 
 		Namespace: p.ToPeripheralResourceNamespace(),
 	}
 	if err := r.SvcClient.Get(ctx, ns, cm); err != nil {
-		return fmt.Errorf("error while getting the pod environment configmap from service cluster: %w", err)
+		// when updating from v0.7.0 straight to v0.10.0, we neither have that ConfigMap (as we use a Secret in version
+		// v0.7.0) nor do we create it (the new labels aren't there yet, so the selector does not match and
+		// operatormanager.OperatorManager.UpdateAllManagedOperators does not call InstallOrUpdateOperator)
+		// we previously aborted here (before the postgresql resource was updated with the new labels), meaning we would
+		// simply restart the loop without solving the problem.
+		if err := r.SvcClient.Create(ctx, cm); err != nil {
+			return fmt.Errorf("error while creating the missing Pod Environment ConfigMap: %w", err)
+		}
+		log.Info("mising Pod Environment ConfigMap created!")
 	}
 	cm.Data = data
 	if err := r.SvcClient.Update(ctx, cm); err != nil {

--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -391,7 +391,7 @@ func (r *PostgresReconciler) ensureZalandoDependencies(ctx context.Context, p *p
 }
 
 func (r *PostgresReconciler) updatePodEnvironmentConfigMap(ctx context.Context, p *pg.Postgres) error {
-	log := r.Log.WithValues("namespace", p.Namespace)
+	log := r.Log.WithValues("postgres", p.Name)
 	if p.Spec.BackupSecretRef == "" {
 		log.Info("No configured backupSecretRef found, skipping configuration of postgres backup")
 		return nil

--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -465,7 +465,7 @@ func (r *PostgresReconciler) updatePodEnvironmentConfigMap(ctx context.Context, 
 		if err := r.CreatePodEnvironmentConfigMap(ctx, ns.Namespace); err != nil {
 			return fmt.Errorf("error while creating the missing Pod Environment ConfigMap %v: %w", ns.Namespace, err)
 		}
-		log.Info("mising Pod Environment ConfigMap created!")
+		return fmt.Errorf("mising Pod Environment ConfigMap created, requeueing: %w", err)
 	}
 	cm.Data = data
 	if err := r.SvcClient.Update(ctx, cm); err != nil {

--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -462,7 +462,7 @@ func (r *PostgresReconciler) updatePodEnvironmentConfigMap(ctx context.Context, 
 		// operatormanager.OperatorManager.UpdateAllManagedOperators does not call InstallOrUpdateOperator)
 		// we previously aborted here (before the postgresql resource was updated with the new labels), meaning we would
 		// simply restart the loop without solving the problem.
-		if cm, err = r.CreatePodEnvironmentConfigMap(ctx, ns.Namespace); err != nil {
+		if err := r.CreatePodEnvironmentConfigMap(ctx, ns.Namespace); err != nil {
 			return fmt.Errorf("error while creating the missing Pod Environment ConfigMap %v: %w", ns.Namespace, err)
 		}
 		log.Info("mising Pod Environment ConfigMap created!")

--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -462,7 +462,7 @@ func (r *PostgresReconciler) updatePodEnvironmentConfigMap(ctx context.Context, 
 		// operatormanager.OperatorManager.UpdateAllManagedOperators does not call InstallOrUpdateOperator)
 		// we previously aborted here (before the postgresql resource was updated with the new labels), meaning we would
 		// simply restart the loop without solving the problem.
-		if err := r.CreatePodEnvironmentConfigMap(ctx, ns.Namespace); err != nil {
+		if cm, err = r.CreatePodEnvironmentConfigMap(ctx, ns.Namespace); err != nil {
 			return fmt.Errorf("error while creating the missing Pod Environment ConfigMap %v: %w", ns.Namespace, err)
 		}
 		log.Info("mising Pod Environment ConfigMap created!")

--- a/pkg/operatormanager/operatormanager.go
+++ b/pkg/operatormanager/operatormanager.go
@@ -120,7 +120,7 @@ func (m *OperatorManager) InstallOrUpdateOperator(ctx context.Context, namespace
 	}
 
 	// Add our (initially empty) custom pod environment configmap
-	if err := m.CreatePodEnvironmentConfigMap(ctx, namespace); err != nil {
+	if _, err := m.CreatePodEnvironmentConfigMap(ctx, namespace); err != nil {
 		return fmt.Errorf("error while creating pod environment configmap %v: %w", namespace, err)
 	}
 
@@ -463,32 +463,32 @@ func (m *OperatorManager) createNamespace(ctx context.Context, namespace string)
 }
 
 // CreatePodEnvironmentConfigMap creates a new ConfigMap with additional environment variables for the pods
-func (m *OperatorManager) CreatePodEnvironmentConfigMap(ctx context.Context, namespace string) error {
+func (m *OperatorManager) CreatePodEnvironmentConfigMap(ctx context.Context, namespace string) (*corev1.ConfigMap, error) {
 	ns := types.NamespacedName{
 		Namespace: namespace,
 		Name:      PodEnvCMName,
 	}
-	if err := m.Get(ctx, ns, &corev1.ConfigMap{}); err == nil {
+	cm := &corev1.ConfigMap{}
+	if err := m.Get(ctx, ns, cm); err == nil {
 		// configmap already exists, nothing to do here
 		// we will update the configmap with the correct S3 config in the postgres controller
 		m.log.Info("Pod Environment ConfigMap already exists")
-		return nil
+		return cm, nil
 	}
 
-	cm := &corev1.ConfigMap{}
 	if err := m.SetName(cm, PodEnvCMName); err != nil {
-		return fmt.Errorf("error while setting the name of the new Pod Environment ConfigMap to %v: %w", namespace, err)
+		return nil, fmt.Errorf("error while setting the name of the new Pod Environment ConfigMap to %v: %w", namespace, err)
 	}
 	if err := m.SetNamespace(cm, namespace); err != nil {
-		return fmt.Errorf("error while setting the namespace of the new Pod Environment ConfigMap to %v: %w", namespace, err)
+		return nil, fmt.Errorf("error while setting the namespace of the new Pod Environment ConfigMap to %v: %w", namespace, err)
 	}
 
 	if err := m.Create(ctx, cm); err != nil {
-		return fmt.Errorf("error while creating the new Pod Environment ConfigMap: %w", err)
+		return nil, fmt.Errorf("error while creating the new Pod Environment ConfigMap: %w", err)
 	}
 	m.log.Info("new Pod Environment ConfigMap created")
 
-	return nil
+	return cm, nil
 }
 
 func (m *OperatorManager) createOrUpdateSidecarsConfig(ctx context.Context, namespace string) error {

--- a/pkg/operatormanager/operatormanager.go
+++ b/pkg/operatormanager/operatormanager.go
@@ -120,7 +120,7 @@ func (m *OperatorManager) InstallOrUpdateOperator(ctx context.Context, namespace
 	}
 
 	// Add our (initially empty) custom pod environment configmap
-	if err := m.createPodEnvironmentConfigMap(ctx, namespace); err != nil {
+	if err := m.CreatePodEnvironmentConfigMap(ctx, namespace); err != nil {
 		return fmt.Errorf("error while creating pod environment configmap %v: %w", namespace, err)
 	}
 
@@ -462,8 +462,8 @@ func (m *OperatorManager) createNamespace(ctx context.Context, namespace string)
 	return nil
 }
 
-// createPodEnvironmentConfigMap creates a new ConfigMap with additional environment variables for the pods
-func (m *OperatorManager) createPodEnvironmentConfigMap(ctx context.Context, namespace string) error {
+// CreatePodEnvironmentConfigMap creates a new ConfigMap with additional environment variables for the pods
+func (m *OperatorManager) CreatePodEnvironmentConfigMap(ctx context.Context, namespace string) error {
 	ns := types.NamespacedName{
 		Namespace: namespace,
 		Name:      PodEnvCMName,


### PR DESCRIPTION
When updating from `v0.7.0` straight to `v0.10.0`, there is a logic gap that prevents reconciliation.

There are of course several possible solutions, but the one with the least impact ist simply creating that missing `ConfigMap`.