### PR TITLE
CLONE_WALG_LIBSODIUM_KEY

### DIFF
--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -527,6 +527,8 @@ func (r *PostgresReconciler) updatePodEnvironmentSecret(ctx context.Context, p *
 			return fmt.Errorf("wal_g encryption key must be exactly 32 bytes, got %v", len(k))
 		}
 		data["WALG_LIBSODIUM_KEY"] = k
+		// TODO can we somehow obtain the remote key, e.g. when cloning from a different partition?
+		data["CLONE_WALG_LIBSODIUM_KEY"] = k
 	}
 
 	var s *corev1.Secret


### PR DESCRIPTION
Also set the CLONE_WALG_LIBSODIUM_KEY variable so that clones from encrypted backups work as well