### PR TITLE
Standby create replica methods

### DIFF
--- a/api/v1/postgres_types.go
+++ b/api/v1/postgres_types.go
@@ -858,6 +858,14 @@ func (p *Postgres) IsReplicationPrimary() bool {
 	return false
 }
 
+func (p *Postgres) IsReplicationTarget() bool {
+	if p.Spec.PostgresConnection != nil && p.Spec.PostgresConnection.ReplicationPrimary == false {
+		// sth is configured and we are not the leader
+		return true
+	}
+	return false
+}
+
 // enableAuditLogs configures this postgres instances audit logging
 func enableAuditLogs(parameters map[string]string) {
 	// default values: bg_mon,pg_stat_statements,pgextwlist,pg_auth_mon,set_user,timescaledb,pg_cron,pg_stat_kcache

--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -958,6 +958,7 @@ func (r *PostgresReconciler) httpPatchPatroni(ctx context.Context, instance *pg.
 		Retries                       int    `json:"retries"`
 		ThresholdBackupSizePercentage int    `json:"threshold_backup_size_percentage"`
 		ThresholdMegabytes            int    `json:"threshold_megabytes"`
+		DataDir                       string `json:"datadir"`
 	}
 	type PatroniStandbyCluster struct {
 		CreateReplicaMethods []string    `json:"create_replica_methods"`
@@ -998,6 +999,7 @@ func (r *PostgresReconciler) httpPatchPatroni(ctx context.Context, instance *pg.
 					Retries:                       2,
 					ThresholdBackupSizePercentage: 100,
 					ThresholdMegabytes:            102400,
+					DataDir:                       "/home/postgres/pgdata/pgroot/data",
 				},
 			},
 			SynchronousNodesAdditional: nil,

--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -588,6 +588,10 @@ func (r *PostgresReconciler) updatePodEnvironmentSecret(ctx context.Context, p *
 		} else {
 			delete(data, "CLONE_WALG_LIBSODIUM_KEY")
 		}
+
+		if p.IsReplicationTarget() {
+			data["STANDBY_WALG_LIBSODIUM_KEY"] = k
+		}
 	}
 
 	// check if is standby
@@ -661,9 +665,6 @@ func (r *PostgresReconciler) updatePodEnvironmentSecret(ctx context.Context, p *
 
 		data["STANDBY_WALG_S3_PREFIX"] = []byte(primaryWalGS3Prefix)
 
-		if r.EnableWalGEncryption {
-			data["STANDBY_WALG_LIBSODIUM_KEY"] = k
-		}
 	}
 
 	var s *corev1.Secret

--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -1057,9 +1057,10 @@ func (r *PostgresReconciler) httpPatchPatroni(ctx context.Context, instance *pg.
 		// TODO check values first
 		request = PatroniConfigRequest{
 			StandbyCluster: &PatroniStandbyCluster{
-				Host:            instance.Spec.PostgresConnection.ConnectionIP,
-				Port:            int(instance.Spec.PostgresConnection.ConnectionPort),
-				ApplicationName: instance.ObjectMeta.Name,
+				CreateReplicaMethods: []string{"basebackup_fast_xlog"},
+				Host:                 instance.Spec.PostgresConnection.ConnectionIP,
+				Port:                 int(instance.Spec.PostgresConnection.ConnectionPort),
+				ApplicationName:      instance.ObjectMeta.Name,
 			},
 			SynchronousNodesAdditional: nil,
 		}

--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -493,6 +493,12 @@ func (r *PostgresReconciler) updatePodEnvironmentConfigMap(ctx context.Context, 
 		"CLONE_WALG_DOWNLOAD_CONCURRENCY":    downloadConcurrency,
 	}
 
+	if p.IsReplicationTarget() {
+		data["STANDBY_WALG_UPLOAD_DISK_CONCURRENCY"] = uploadDiskConcurrency
+		data["STANDBY_WALG_UPLOAD_CONCURRENCY"] = uploadConcurrency
+		data["STANDBY_WALG_DOWNLOAD_CONCURRENCY"] = downloadConcurrency
+	}
+
 	cm := &corev1.ConfigMap{}
 	ns := types.NamespacedName{
 		Name:      operatormanager.PodEnvCMName,

--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -560,82 +560,18 @@ func (r *PostgresReconciler) updatePodEnvironmentSecret(ctx context.Context, p *
 			delete(data, "CLONE_WALG_LIBSODIUM_KEY")
 		}
 
+		// we also need that (hopefully identical) key to bootstrap from files in S3
 		if p.IsReplicationTarget() {
 			data["STANDBY_WALG_LIBSODIUM_KEY"] = k
 		}
 	}
 
-	// check if is standby
+	// add STANDBY_* variables for bootstrapping from S3
 	if p.IsReplicationTarget() {
-		// if standby, fetch backup secret of primary
-		primary := &pg.Postgres{}
-		ns := types.NamespacedName{
-			Name:      p.Spec.PostgresConnection.ConnectedPostgresID,
-			Namespace: p.Namespace,
+		standbyEnvs := r.getStandbyEnvs(ctx, p)
+		for name, value := range standbyEnvs {
+			data[name] = value
 		}
-		if err := r.CtrlClient.Get(ctx, ns, primary); err != nil {
-			if apierrors.IsNotFound(err) {
-				// the instance was updated, but does not exist anymore -> do nothing, it was probably deleted
-				return nil
-			}
-
-			r.recorder.Eventf(primary, "Warning", "Error", "failed to get resource: %v", err)
-			return err
-		}
-		log.Info("postgres fetched", "postgres", primary)
-
-		if primary.Spec.BackupSecretRef == "" {
-			log.Info("No configured backupSecretRef found, skipping configuration of postgres backup")
-			return nil
-		}
-
-		primaryBackupConfig, err := r.getBackupConfig(ctx, primary.Namespace, primary.Spec.BackupSecretRef)
-		if err != nil {
-			return err
-		}
-		primaryS3url, err := url.Parse(primaryBackupConfig.S3Endpoint)
-		if err != nil {
-			return fmt.Errorf("error while parsing the s3 endpoint url in the backup secret: %w", err)
-		}
-		// use the s3 endpoint as provided
-		primaryAwsEndpoint := primaryS3url.String()
-		// modify the scheme to 'https+path'
-		primaryS3url.Scheme = "https+path"
-		// use the modified s3 endpoint
-		primaryWalES3Endpoint := primaryS3url.String()
-		// region
-		primaryRegion := primaryBackupConfig.S3Region
-
-		primaryWalGS3Prefix := "s3://" + primaryBackupConfig.S3BucketName + "/" + primary.ToPeripheralResourceName()
-
-		// s3 server side encryption SSE is disabled
-		// we use client side encryption
-		primaryWalgDisableSSE := "true"
-
-		// if available, set STANDBY_ variables:
-
-		primaryAwsAccessKeyID := primaryBackupConfig.S3AccessKey
-		primaryAwsSecretAccessKey := primaryBackupConfig.S3SecretKey
-
-		// create updated content for pod environment configmap
-		data["STANDBY_AWS_ACCESS_KEY_ID"] = []byte(primaryAwsAccessKeyID)
-		data["STANDBY_AWS_SECRET_ACCESS_KEY"] = []byte(primaryAwsSecretAccessKey)
-
-		data["STANDBY_AWS_ENDPOINT"] = []byte(primaryAwsEndpoint)
-		data["STANDBY_WALE_S3_ENDPOINT"] = []byte(primaryWalES3Endpoint)     // same as above, but slightly modified
-		data["STANDBY_WALG_S3_ENDPOINT"] = []byte(primaryWalES3Endpoint)     // same as above, but slightly modified
-		data["STANDBY_AWS_WALG_S3_ENDPOINT"] = []byte(primaryWalES3Endpoint) // same as above, but slightly modified
-		data["STANDBY_AWS_S3_FORCE_PATH_STYLE"] = []byte("true")
-		data["STANDBY_AWS_REGION"] = []byte(primaryRegion)                  // now we can use AWS S3
-		data["STANDBY_WALG_DISABLE_S3_SSE"] = []byte(primaryWalgDisableSSE) // server side encryption
-		data["STANDBY_WALG_S3_SSE"] = []byte("")                            // server side encryption
-
-		data["STANDBY_WITH_WALG"] = []byte("true")
-		data["STANDBY_USE_WALG_BACKUP"] = []byte("true")
-		data["STANDBY_USE_WALG_RESTORE"] = []byte("true")
-
-		data["STANDBY_WALG_S3_PREFIX"] = []byte(primaryWalGS3Prefix)
-
 	}
 
 	var s *corev1.Secret
@@ -654,6 +590,80 @@ func (r *PostgresReconciler) updatePodEnvironmentSecret(ctx context.Context, p *
 	}
 
 	return nil
+}
+
+// getStandbyEnvs Fetches all the required info from the remote primary postgres and fills all ENVS required for bootstrapping from S3
+func (r *PostgresReconciler) getStandbyEnvs(ctx context.Context, p *pg.Postgres) map[string][]byte {
+	standbyEnvs := map[string][]byte{}
+
+	// fetch backup secret of primary
+	primary := &pg.Postgres{}
+	ns := types.NamespacedName{
+		Name:      p.Spec.PostgresConnection.ConnectedPostgresID,
+		Namespace: p.Namespace,
+	}
+	if err := r.CtrlClient.Get(ctx, ns, primary); err != nil {
+		if apierrors.IsNotFound(err) {
+			// the instance was updated, but does not exist anymore -> do nothing, it was probably deleted
+			return standbyEnvs
+		}
+
+		r.recorder.Eventf(primary, "Warning", "Error", "failed to get referenced primary postgres: %v", err)
+		return standbyEnvs
+	}
+
+	if primary.Spec.BackupSecretRef == "" {
+		r.recorder.Eventf(primary, "Warning", "Error", "No backupSecretRef for primary postgres found, skipping configuration of wal_e bootstrapping")
+		return standbyEnvs
+	}
+
+	primaryBackupConfig, err := r.getBackupConfig(ctx, primary.Namespace, primary.Spec.BackupSecretRef)
+	if err != nil {
+		r.recorder.Eventf(primary, "Warning", "Error", "failed to get referenced primary backup config, skipping configuration of wal_e bootstrapping: %v", err)
+		return standbyEnvs
+	}
+	primaryS3url, err := url.Parse(primaryBackupConfig.S3Endpoint)
+	if err != nil {
+		r.recorder.Eventf(primary, "Warning", "Error", "error while parsing the s3 endpoint url in the backup secret: %w", err)
+		return standbyEnvs
+	}
+
+	// use the s3 endpoint as provided
+	primaryAwsEndpoint := primaryS3url.String()
+	// modify the scheme to 'https+path'
+	primaryS3url.Scheme = "https+path"
+	// use the modified s3 endpoint
+	primaryWalES3Endpoint := primaryS3url.String()
+	// region
+	primaryRegion := primaryBackupConfig.S3Region
+	// s3 prefix
+	primaryWalGS3Prefix := "s3://" + primaryBackupConfig.S3BucketName + "/" + primary.ToPeripheralResourceName()
+	// s3 server side encryption SSE is disabled, we use client side encryption
+	// see STANDBY_WALG_LIBSODIUM_KEY above
+	primaryWalgDisableSSE := "true"
+	// aws access key
+	primaryAwsAccessKeyID := primaryBackupConfig.S3AccessKey
+	// aws secret key
+	primaryAwsSecretAccessKey := primaryBackupConfig.S3SecretKey
+
+	// create updated content for pod environment configmap
+	// this is a bit confusing: those are used to bootstrap a remote standby, so they have to point to the primary!
+	standbyEnvs["STANDBY_AWS_ACCESS_KEY_ID"] = []byte(primaryAwsAccessKeyID)
+	standbyEnvs["STANDBY_AWS_SECRET_ACCESS_KEY"] = []byte(primaryAwsSecretAccessKey)
+	standbyEnvs["STANDBY_AWS_ENDPOINT"] = []byte(primaryAwsEndpoint)
+	standbyEnvs["STANDBY_AWS_S3_FORCE_PATH_STYLE"] = []byte("true")
+	standbyEnvs["STANDBY_AWS_REGION"] = []byte(primaryRegion)
+	standbyEnvs["STANDBY_AWS_WALG_S3_ENDPOINT"] = []byte(primaryWalES3Endpoint)
+	standbyEnvs["STANDBY_USE_WALG_BACKUP"] = []byte("true")
+	standbyEnvs["STANDBY_USE_WALG_RESTORE"] = []byte("true")
+	standbyEnvs["STANDBY_WALE_S3_ENDPOINT"] = []byte(primaryWalES3Endpoint)
+	standbyEnvs["STANDBY_WALG_DISABLE_S3_SSE"] = []byte(primaryWalgDisableSSE)
+	standbyEnvs["STANDBY_WALG_S3_ENDPOINT"] = []byte(primaryWalES3Endpoint)
+	standbyEnvs["STANDBY_WALG_S3_PREFIX"] = []byte(primaryWalGS3Prefix)
+	standbyEnvs["STANDBY_WALG_S3_SSE"] = []byte("")
+	standbyEnvs["STANDBY_WITH_WALG"] = []byte("true")
+
+	return standbyEnvs
 }
 
 func (r *PostgresReconciler) isManagedByUs(obj *pg.Postgres) bool {

--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -102,17 +102,17 @@ type PatroniBootstrap struct {
 	DCS PatroniDCS `json:"dcs"`
 }
 type PatroniStandbyCluster struct {
-	CreateReplicaMethods []string           `json:"create_replica_methods,omitempty"`
-	Host                 string             `json:"host,omitempty"`
-	Port                 int                `json:"port,omitempty"`
-	ApplicationName      string             `json:"application_name,omitempty"`
-	S3Bootstrap          PatroniS3Bootstrap `json:"s3_bootstrap,omitempty"`
-	Bootstrap            PatroniBootstrap   `json:"bootstrap,omitempty"`
+	CreateReplicaMethods *[]string           `json:"create_replica_methods,omitempty"`
+	Host                 *string             `json:"host,omitempty"`
+	Port                 *int                `json:"port,omitempty"`
+	ApplicationName      *string             `json:"application_name,omitempty"`
+	S3Bootstrap          *PatroniS3Bootstrap `json:"s3_bootstrap,omitempty"`
+	Bootstrap            *PatroniBootstrap   `json:"bootstrap,omitempty"`
 }
 type PatroniConfigRequest struct {
 	StandbyCluster             *PatroniStandbyCluster `json:"standby_cluster"`
 	SynchronousNodesAdditional *string                `json:"synchronous_nodes_additional"`
-	Bootstrap                  PatroniBootstrap       `json:"bootstrap"`
+	Bootstrap                  *PatroniBootstrap      `json:"bootstrap"`
 }
 
 // Reconcile is the entry point for postgres reconciliation.
@@ -1065,11 +1065,11 @@ func (r *PostgresReconciler) httpPatchPatroni(ctx context.Context, instance *pg.
 		// TODO check values first
 		request = PatroniConfigRequest{
 			StandbyCluster: &PatroniStandbyCluster{
-				// CreateReplicaMethods: []string{"s3_bootstrap", "basebackup_fast_xlog"},
-				Host:            instance.Spec.PostgresConnection.ConnectionIP,
-				Port:            int(instance.Spec.PostgresConnection.ConnectionPort),
-				ApplicationName: instance.ObjectMeta.Name,
-				S3Bootstrap: PatroniS3Bootstrap{
+				CreateReplicaMethods: &[]string{"s3_bootstrap", "basebackup_fast_xlog"},
+				Host:                 &instance.Spec.PostgresConnection.ConnectionIP,
+				Port:                 pointer.Int(int(instance.Spec.PostgresConnection.ConnectionPort)),
+				ApplicationName:      &instance.ObjectMeta.Name,
+				S3Bootstrap: &PatroniS3Bootstrap{
 					Command:                       "envdir /run/etc/wal-e.d/env-standby bash /scripts/wale_restore.sh",
 					NoMaster:                      1,
 					Retries:                       2,
@@ -1079,10 +1079,10 @@ func (r *PostgresReconciler) httpPatchPatroni(ctx context.Context, instance *pg.
 				},
 			},
 			SynchronousNodesAdditional: nil,
-			Bootstrap: PatroniBootstrap{
+			Bootstrap: &PatroniBootstrap{
 				DCS: PatroniDCS{
 					StandbyCluster: &PatroniStandbyCluster{
-						CreateReplicaMethods: []string{"s3_bootstrap", "basebackup_fast_xlog"},
+						CreateReplicaMethods: &[]string{"s3_bootstrap", "basebackup_fast_xlog"},
 					},
 				},
 			},

--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -87,7 +87,7 @@ type PostgresReconciler struct {
 	PostgresletFullname                 string
 }
 
-type PatroniWalEStandby struct {
+type PatroniS3Bootstrap struct {
 	Command                       string `json:"host"`
 	NoMaster                      int    `json:"no_master"`
 	Retries                       int    `json:"retries"`
@@ -106,7 +106,7 @@ type PatroniStandbyCluster struct {
 	Host                 string             `json:"host,omitempty"`
 	Port                 int                `json:"port,omitempty"`
 	ApplicationName      string             `json:"application_name,omitempty"`
-	WalEStandby          PatroniWalEStandby `json:"wal_e_standby,omitempty"`
+	S3Bootstrap          PatroniS3Bootstrap `json:"s3_bootstrap,omitempty"`
 	Bootstrap            PatroniBootstrap   `json:"bootstrap,omitempty"`
 }
 type PatroniConfigRequest struct {
@@ -1065,11 +1065,11 @@ func (r *PostgresReconciler) httpPatchPatroni(ctx context.Context, instance *pg.
 		// TODO check values first
 		request = PatroniConfigRequest{
 			StandbyCluster: &PatroniStandbyCluster{
-				// CreateReplicaMethods: []string{"wal_e_standby", "basebackup_fast_xlog"},
+				// CreateReplicaMethods: []string{"s3_bootstrap", "basebackup_fast_xlog"},
 				Host:            instance.Spec.PostgresConnection.ConnectionIP,
 				Port:            int(instance.Spec.PostgresConnection.ConnectionPort),
 				ApplicationName: instance.ObjectMeta.Name,
-				WalEStandby: PatroniWalEStandby{
+				S3Bootstrap: PatroniS3Bootstrap{
 					Command:                       "envdir /run/etc/wal-e.d/env-standby bash /scripts/wale_restore.sh",
 					NoMaster:                      1,
 					Retries:                       2,
@@ -1082,7 +1082,7 @@ func (r *PostgresReconciler) httpPatchPatroni(ctx context.Context, instance *pg.
 			Bootstrap: PatroniBootstrap{
 				DCS: PatroniDCS{
 					StandbyCluster: &PatroniStandbyCluster{
-						CreateReplicaMethods: []string{"wal_e_standby", "basebackup_fast_xlog"},
+						CreateReplicaMethods: []string{"s3_bootstrap", "basebackup_fast_xlog"},
 					},
 				},
 			},

--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -87,32 +87,34 @@ type PostgresReconciler struct {
 	PostgresletFullname                 string
 }
 
-type PatroniS3Bootstrap struct {
-	Command                       string `json:"host"`
-	NoMaster                      int    `json:"no_master"`
-	Retries                       int    `json:"retries"`
-	ThresholdBackupSizePercentage int    `json:"threshold_backup_size_percentage"`
-	ThresholdMegabytes            int    `json:"threshold_megabytes"`
-	DataDir                       string `json:"datadir"`
-}
-type PatroniDCS struct {
-	StandbyCluster *PatroniStandbyCluster `json:"standby_cluster"`
-}
-type PatroniBootstrap struct {
-	DCS PatroniDCS `json:"dcs"`
-}
+//	type PatroniS3Bootstrap struct {
+//		Command                       string `json:"host"`
+//		NoMaster                      int    `json:"no_master"`
+//		Retries                       int    `json:"retries"`
+//		ThresholdBackupSizePercentage int    `json:"threshold_backup_size_percentage"`
+//		ThresholdMegabytes            int    `json:"threshold_megabytes"`
+//		DataDir                       string `json:"datadir"`
+//	}
+//
+//	type PatroniDCS struct {
+//		StandbyCluster *PatroniStandbyCluster `json:"standby_cluster"`
+//	}
+//
+//	type PatroniBootstrap struct {
+//		DCS PatroniDCS `json:"dcs"`
+//	}
 type PatroniStandbyCluster struct {
-	CreateReplicaMethods *[]string           `json:"create_replica_methods,omitempty"`
-	Host                 *string             `json:"host,omitempty"`
-	Port                 *int                `json:"port,omitempty"`
-	ApplicationName      *string             `json:"application_name,omitempty"`
-	S3Bootstrap          *PatroniS3Bootstrap `json:"s3_bootstrap,omitempty"`
-	Bootstrap            *PatroniBootstrap   `json:"bootstrap,omitempty"`
+	// CreateReplicaMethods *[]string           `json:"create_replica_methods,omitempty"`
+	Host            *string `json:"host,omitempty"`
+	Port            *int    `json:"port,omitempty"`
+	ApplicationName *string `json:"application_name,omitempty"`
+	// S3Bootstrap          *PatroniS3Bootstrap `json:"s3_bootstrap,omitempty"`
+	// Bootstrap            *PatroniBootstrap   `json:"bootstrap,omitempty"`
 }
 type PatroniConfigRequest struct {
 	StandbyCluster             *PatroniStandbyCluster `json:"standby_cluster"`
 	SynchronousNodesAdditional *string                `json:"synchronous_nodes_additional"`
-	Bootstrap                  *PatroniBootstrap      `json:"bootstrap"`
+	// Bootstrap                  *PatroniBootstrap      `json:"bootstrap"`
 }
 
 // Reconcile is the entry point for postgres reconciliation.
@@ -1074,27 +1076,27 @@ func (r *PostgresReconciler) httpPatchPatroni(ctx context.Context, instance *pg.
 		// TODO check values first
 		request = PatroniConfigRequest{
 			StandbyCluster: &PatroniStandbyCluster{
-				CreateReplicaMethods: &[]string{"s3_bootstrap", "basebackup_fast_xlog"},
-				Host:                 &instance.Spec.PostgresConnection.ConnectionIP,
-				Port:                 pointer.Int(int(instance.Spec.PostgresConnection.ConnectionPort)),
-				ApplicationName:      &instance.ObjectMeta.Name,
-				S3Bootstrap: &PatroniS3Bootstrap{
-					Command:                       "envdir /run/etc/wal-e.d/env-standby bash /scripts/wale_restore.sh",
-					NoMaster:                      1,
-					Retries:                       2,
-					ThresholdBackupSizePercentage: 100,
-					ThresholdMegabytes:            102400,
-					DataDir:                       "/home/postgres/pgdata/pgroot/data",
-				},
+				// CreateReplicaMethods: &[]string{"s3_bootstrap", "basebackup_fast_xlog"},
+				Host:            &instance.Spec.PostgresConnection.ConnectionIP,
+				Port:            pointer.Int(int(instance.Spec.PostgresConnection.ConnectionPort)),
+				ApplicationName: &instance.ObjectMeta.Name,
+				// S3Bootstrap: &PatroniS3Bootstrap{
+				// 	Command:                       "envdir /run/etc/wal-e.d/env-standby bash /scripts/wale_restore.sh",
+				// 	NoMaster:                      1,
+				// 	Retries:                       2,
+				// 	ThresholdBackupSizePercentage: 100,
+				// 	ThresholdMegabytes:            102400,
+				// 	DataDir:                       "/home/postgres/pgdata/pgroot/data",
+				// },
 			},
 			SynchronousNodesAdditional: nil,
-			Bootstrap: &PatroniBootstrap{
-				DCS: PatroniDCS{
-					StandbyCluster: &PatroniStandbyCluster{
-						CreateReplicaMethods: &[]string{"s3_bootstrap", "basebackup_fast_xlog"},
-					},
-				},
-			},
+			// Bootstrap: &PatroniBootstrap{
+			// 	DCS: PatroniDCS{
+			// 		StandbyCluster: &PatroniStandbyCluster{
+			// 			CreateReplicaMethods: &[]string{"s3_bootstrap", "basebackup_fast_xlog"},
+			// 		},
+			// 	},
+			// },
 		}
 	}
 	r.Log.Info("Prepared request", "request", request)

--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -567,7 +567,6 @@ func (r *PostgresReconciler) updatePodEnvironmentSecret(ctx context.Context, p *
 	}
 
 	// libsodium client side encryption key
-	var k []byte
 	if r.EnableWalGEncryption {
 		s, err := r.getWalGEncryptionSecret(ctx)
 		if err != nil {

--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -631,6 +631,8 @@ func (r *PostgresReconciler) updatePodEnvironmentSecret(ctx context.Context, p *
 		// region
 		primaryRegion := primaryBackupConfig.S3Region
 
+		primaryWalGS3Prefix := "s3://" + primaryBackupConfig.S3BucketName + "/" + primary.ToPeripheralResourceName()
+
 		// s3 server side encryption SSE is disabled
 		// we use client side encryption
 		primaryWalgDisableSSE := "true"
@@ -645,12 +647,19 @@ func (r *PostgresReconciler) updatePodEnvironmentSecret(ctx context.Context, p *
 		data["STANDBY_AWS_SECRET_ACCESS_KEY"] = []byte(primaryAwsSecretAccessKey)
 
 		data["STANDBY_AWS_ENDPOINT"] = []byte(primaryAwsEndpoint)
-		data["STANDBY_WALE_S3_ENDPOINT"] = []byte(primaryWalES3Endpoint) // same as above, but slightly modified
+		data["STANDBY_WALE_S3_ENDPOINT"] = []byte(primaryWalES3Endpoint)     // same as above, but slightly modified
+		data["STANDBY_WALG_S3_ENDPOINT"] = []byte(primaryWalES3Endpoint)     // same as above, but slightly modified
+		data["STANDBY_AWS_WALG_S3_ENDPOINT"] = []byte(primaryWalES3Endpoint) // same as above, but slightly modified
 		data["STANDBY_AWS_S3_FORCE_PATH_STYLE"] = []byte("true")
 		data["STANDBY_AWS_REGION"] = []byte(primaryRegion)                  // now we can use AWS S3
 		data["STANDBY_WALG_DISABLE_S3_SSE"] = []byte(primaryWalgDisableSSE) // server side encryption
+		data["STANDBY_WALG_S3_SSE"] = []byte("")                            // server side encryption
 
 		data["STANDBY_WITH_WALG"] = []byte("true")
+		data["STANDBY_USE_WALG_BACKUP"] = []byte("true")
+		data["STANDBY_USE_WALG_RESTORE"] = []byte("true")
+
+		data["STANDBY_WALG_S3_PREFIX"] = []byte(primaryWalGS3Prefix)
 
 		if r.EnableWalGEncryption {
 			data["STANDBY_WALG_LIBSODIUM_KEY"] = k

--- a/main.go
+++ b/main.go
@@ -72,6 +72,7 @@ const (
 	enableRandomStorageEncrytionSecretFlg = "enable-random-storage-encryption-secret"
 	enableWalGEncryptionFlg               = "enable-walg-encryption"
 	enableForceSharedIPFlg                = "enable-force-shared-ip"
+	enableBootstrapStandbyFromS3Flg       = "enable-bootsrtap-standby-from-s3"
 )
 
 var (
@@ -124,6 +125,7 @@ func main() {
 		enableRandomStorageEncrytionSecret bool
 		enableWalGEncryption               bool
 		enableForceSharedIP                bool
+		enableBootstrapStandbyFromS3       bool
 
 		portRangeStart int
 		portRangeSize  int
@@ -260,6 +262,9 @@ func main() {
 	viper.SetDefault(enableForceSharedIPFlg, true) // TODO switch to false?
 	enableForceSharedIP = viper.GetBool(enableForceSharedIPFlg)
 
+	viper.SetDefault(enableBootstrapStandbyFromS3Flg, true)
+	enableBootstrapStandbyFromS3 = viper.GetBool(enableBootstrapStandbyFromS3Flg)
+
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
 	ctrl.Log.Info("flag",
@@ -299,6 +304,7 @@ func main() {
 		postgresletFullnameFlg, postgresletFullname,
 		enableWalGEncryptionFlg, enableWalGEncryption,
 		enableForceSharedIPFlg, enableForceSharedIP,
+		enableBootstrapStandbyFromS3Flg, enableBootstrapStandbyFromS3,
 	)
 
 	svcClusterConf := ctrl.GetConfigOrDie()
@@ -406,6 +412,7 @@ func main() {
 		EnableRandomStorageEncryptionSecret: enableRandomStorageEncrytionSecret,
 		EnableWalGEncryption:                enableWalGEncryption,
 		PostgresletFullname:                 postgresletFullname,
+		EnableBootstrapStandbyFromS3:        enableBootstrapStandbyFromS3,
 	}).SetupWithManager(ctrlPlaneClusterMgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Postgres")
 		os.Exit(1)


### PR DESCRIPTION
* Add additional create_replica_method
* Add `STANDBY_*` variables 

In theory, this should allow us to simply bootstrap a standby via S3:

```
patronictl remove <clustername>
```

```yaml
env:
- name: STANDBY_USE_WALG_BACKUP
  value: "true"
- name: STANDBY_USE_WALG_RESTORE
  value: "true"
- name: STANDBY_WITH_WALG
  value: "true"
- name: STANDBY_AWS_ACCESS_KEY
  value: "BAR"
- name: STANDBY_AWS_SECRET_ACCESS_KEY
  value: "FOO"
- name: STANDBY_AWS_REGION
  value: "us-east-1"
- name: STANDBY_AWS_ENDPOINT
  value: "https://foobar"
- name: STANDBY_AWS_WALG_S3_ENDPOINT
  value: "https+path://foobar"
- name: STANDBY_AWS_S3_FORCE_PATH_STYLE
  value: "true"
- name: STANDBY_AWS_REGION
  value: "us-east-1"
- name: STANDBY_WALG_DISABLE_S3_SSE
  value: "true"
- name: STANDBY_WALG_S3_SSE
  value: ""
- name: STANDBY_WALG_S3_PREFIX
  value: "s3://foo/bar"
- name: STANDBY_WALG_S3_ENDPOINT
  value: "https+path://foobar"
```
