### PR TITLE
Force rolling update on reconcile for testing

### DIFF
--- a/api/v1/postgres_types.go
+++ b/api/v1/postgres_types.go
@@ -613,7 +613,7 @@ func (p *Postgres) ToUnstructuredZalandoPostgresql(z *zalando.Postgresql, c *cor
 	// TODO once all the custom resources have that new label, move this part to p.ToZalandoPostgresqlMatchingLabels()
 	z.Labels[PartitionIDLabelName] = p.Spec.PartitionID
 	// TODO REMOVE temp label
-	z.Labels["postgres.database.fits.cloud/temp-changing-label"] = time.Now().Format(time.RFC3339)
+	z.Labels["postgres.database.fits.cloud/temp-changing-label"] = fmt.Sprint(time.Now().Unix())
 
 	z.Spec.NumberOfInstances = p.Spec.NumberOfInstances
 	z.Spec.PostgresqlParam.PgVersion = p.Spec.Version

--- a/api/v1/postgres_types.go
+++ b/api/v1/postgres_types.go
@@ -612,6 +612,8 @@ func (p *Postgres) ToUnstructuredZalandoPostgresql(z *zalando.Postgresql, c *cor
 	// Add the newly introduced label only here, not in  p.ToZalandoPostgresqlMatchingLabels() (so that the selectors using  p.ToZalandoPostgresqlMatchingLabels() will still work untill all postgres resources have that new label)
 	// TODO once all the custom resources have that new label, move this part to p.ToZalandoPostgresqlMatchingLabels()
 	z.Labels[PartitionIDLabelName] = p.Spec.PartitionID
+	// TODO REMOVE temp label
+	z.Labels["postgres.database.fits.cloud/temp-changing-label"] = time.Now().Format(time.RFC3339)
 
 	z.Spec.NumberOfInstances = p.Spec.NumberOfInstances
 	z.Spec.PostgresqlParam.PgVersion = p.Spec.Version

--- a/pkg/etcdmanager/etcdmanager.go
+++ b/pkg/etcdmanager/etcdmanager.go
@@ -317,7 +317,7 @@ func (m *EtcdManager) createNewClientObject(ctx context.Context, obj client.Obje
 		v.Spec.Template.ObjectMeta.Labels[pg.NameLabelName] = stsName
 		// TODO REMOVE ME
 		// add an ever-changing label to force a rolling update each time we reconcile etcd
-		v.Spec.Template.ObjectMeta.Labels["postgres.database.fits.cloud/temp-changing-label"] = time.Now().Format(time.RFC3339)
+		v.Spec.Template.ObjectMeta.Labels["postgres.database.fits.cloud/temp-changing-label"] = fmt.Sprint(time.Now().Unix())
 
 		m.log.Info("Updating selector")
 		// spec.selector.matchLabels

--- a/pkg/etcdmanager/etcdmanager.go
+++ b/pkg/etcdmanager/etcdmanager.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	pg "github.com/fi-ts/postgreslet/api/v1"
 	"github.com/go-logr/logr"
@@ -314,6 +315,9 @@ func (m *EtcdManager) createNewClientObject(ctx context.Context, obj client.Obje
 		v.Spec.Template.ObjectMeta.Labels[pg.ManagedByLabelName] = m.options.PostgresletFullname
 		v.Spec.Template.ObjectMeta.Labels[etcdComponentLabelName] = etcdComponentLabelValue
 		v.Spec.Template.ObjectMeta.Labels[pg.NameLabelName] = stsName
+		// TODO REMOVE ME
+		// add an ever-changing label to force a rolling update each time we reconcile etcd
+		v.Spec.Template.ObjectMeta.Labels["postgres.database.fits.cloud/temp-changing-label"] = time.Now().Format(time.RFC3339)
 
 		m.log.Info("Updating selector")
 		// spec.selector.matchLabels

--- a/pkg/operatormanager/operatormanager.go
+++ b/pkg/operatormanager/operatormanager.go
@@ -410,7 +410,8 @@ func (m *OperatorManager) editConfigMap(cm *corev1.ConfigMap, namespace string, 
 	// set the reference to our custom pod environment secret
 	cm.Data["pod_environment_secret"] = PodEnvSecretName
 	// set the list of inherited labels that will be passed on to the pods
-	s := []string{pg.TenantLabelName, pg.ProjectIDLabelName, pg.UIDLabelName, pg.NameLabelName}
+	// TODO remove temp changing-label
+	s := []string{pg.TenantLabelName, pg.ProjectIDLabelName, pg.UIDLabelName, pg.NameLabelName, "postgres.database.fits.cloud/temp-changing-label"}
 	// TODO maybe use a precompiled string here
 	cm.Data["inherited_labels"] = strings.Join(s, ",")
 


### PR DESCRIPTION
## Test Branch

This branch introduces a new label to the `etcd` and the `postgresql` custom resource. The value of that label will change each time the etcd or postgresql is reconciled, effectively forcing a rolling update each time.

Meant for testing only.

**DO NOT MERGE!**