### PR TITLE
Reduce patroni retry timeout after moving to failsafe mode

### DIFF
--- a/api/v1/postgres_types.go
+++ b/api/v1/postgres_types.go
@@ -73,7 +73,7 @@ const (
 	teamIDPrefix = "pg"
 
 	DefaultPatroniParamValueLoopWait     uint32 = 10
-	DefaultPatroniParamValueRetryTimeout uint32 = 60
+	DefaultPatroniParamValueRetryTimeout uint32 = 10
 
 	defaultPostgresParamValueTCPKeepAlivesIdle      = "200"
 	defaultPostgresParamValueTCPKeepAlivesInterval  = "30"


### PR DESCRIPTION
Now that we use the K8s API server as DCS again (this time with failsafe mode), we can also lower the default patroni retry timeout to the original default value.