### PR TITLE
add version flag to query build information

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"net"
 	"os"
@@ -171,8 +172,15 @@ func main() {
 		pgParamBlockList map[string]bool
 
 		standbyClusterSourceRanges []string
+
+		showVersion = flag.Bool("version", false, "dump current version and exit")
 	)
 
+	flag.Parse()
+	if *showVersion {
+		fmt.Println(v.V.String())
+		os.Exit(0)
+	}
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
 	// TODO enable Prefix and update helm chart


### PR DESCRIPTION
Add a simple `--version` flag so the binary can print the version number and exit.

~~~
$ bin/manager --version
latest (efcb699a), tags/v0.19.0-0-gefcb699, 2025-05-05T09:55:07+02:00, go1.24.2
~~~

