### PR TITLE
do not use RFC3339 because with zulu time it only adds a Z and no timeshift

### DIFF
--- a/api/v1/postgres_types.go
+++ b/api/v1/postgres_types.go
@@ -103,7 +103,7 @@ const (
 	PostgresConfigAuditorUsername     = "auditor"
 	PostgresConfigMonitoringUsername  = "monitoring"
 
-	ZALANDO_TIMESTAMP_FORMAT = "2006-01-02T15:04:05-07:00"
+	zalando_timestamp_format = "2006-01-02T15:04:05-07:00"
 )
 
 var (
@@ -764,7 +764,7 @@ func (p *Postgres) ToUnstructuredZalandoPostgresql(z *zalando.Postgresql, c *cor
 		// make sure there is always a value set. The operator will fall back to CLONE_WITH_BASEBACKUP, which assumes the source db's credentials are existing within the same namespace, which is not the case with the postgreslet.
 		if p.Spec.PostgresRestore.Timestamp == "" {
 			// e.g. 2021-12-07T15:28:00+01:00
-			p.Spec.PostgresRestore.Timestamp = time.Now().Format(ZALANDO_TIMESTAMP_FORMAT)
+			p.Spec.PostgresRestore.Timestamp = time.Now().Format(zalando_timestamp_format)
 		}
 
 		z.Spec.Clone = &zalando.CloneDescription{

--- a/api/v1/postgres_types.go
+++ b/api/v1/postgres_types.go
@@ -102,6 +102,8 @@ const (
 	PostgresConfigReplicationUsername = "standby"
 	PostgresConfigAuditorUsername     = "auditor"
 	PostgresConfigMonitoringUsername  = "monitoring"
+
+	ZALANDO_TIMESTAMP_FORMAT = "2006-01-02T15:04:05-07:00"
 )
 
 var (
@@ -762,7 +764,7 @@ func (p *Postgres) ToUnstructuredZalandoPostgresql(z *zalando.Postgresql, c *cor
 		// make sure there is always a value set. The operator will fall back to CLONE_WITH_BASEBACKUP, which assumes the source db's credentials are existing within the same namespace, which is not the case with the postgreslet.
 		if p.Spec.PostgresRestore.Timestamp == "" {
 			// e.g. 2021-12-07T15:28:00+01:00
-			p.Spec.PostgresRestore.Timestamp = time.Now().Format(time.RFC3339)
+			p.Spec.PostgresRestore.Timestamp = time.Now().Format(ZALANDO_TIMESTAMP_FORMAT)
 		}
 
 		z.Spec.Clone = &zalando.CloneDescription{

--- a/api/v1/postgres_types_test.go
+++ b/api/v1/postgres_types_test.go
@@ -257,7 +257,7 @@ func TestPostgresRestoreTimestamp_ToUnstructuredZalandoPostgresql(t *testing.T) 
 					Description: "description",
 				},
 			},
-			want:    time.Now().Format(ZALANDO_TIMESTAMP_FORMAT), // I know this is not perfect, let's just hope we always finish within the same second...
+			want:    time.Now().Format(zalando_timestamp_format), // I know this is not perfect, let's just hope we always finish within the same second...
 			wantErr: false,
 		},
 		{
@@ -283,7 +283,7 @@ func TestPostgresRestoreTimestamp_ToUnstructuredZalandoPostgresql(t *testing.T) 
 					Description: "description",
 				},
 			},
-			want:    time.Now().Format(ZALANDO_TIMESTAMP_FORMAT), // I know this is not perfect, let's just hope we always finish within the same second...
+			want:    time.Now().Format(zalando_timestamp_format), // I know this is not perfect, let's just hope we always finish within the same second...
 			wantErr: false,
 		},
 		{

--- a/api/v1/postgres_types_test.go
+++ b/api/v1/postgres_types_test.go
@@ -257,7 +257,7 @@ func TestPostgresRestoreTimestamp_ToUnstructuredZalandoPostgresql(t *testing.T) 
 					Description: "description",
 				},
 			},
-			want:    time.Now().Format(time.RFC3339), // I know this is not perfect, let's just hope we always finish within the same second...
+			want:    time.Now().Format(ZALANDO_TIMESTAMP_FORMAT), // I know this is not perfect, let's just hope we always finish within the same second...
 			wantErr: false,
 		},
 		{
@@ -283,7 +283,7 @@ func TestPostgresRestoreTimestamp_ToUnstructuredZalandoPostgresql(t *testing.T) 
 					Description: "description",
 				},
 			},
-			want:    time.Now().Format(time.RFC3339), // I know this is not perfect, let's just hope we always finish within the same second...
+			want:    time.Now().Format(ZALANDO_TIMESTAMP_FORMAT), // I know this is not perfect, let's just hope we always finish within the same second...
 			wantErr: false,
 		},
 		{


### PR DESCRIPTION
zalando does not support RFC3339 when the timestring only ends with a `Z` (zulu time).