### PR TITLE
Add ontap specific contents to storage-encryption-secret

### DIFF
--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -1797,7 +1797,11 @@ func (r *PostgresReconciler) ensureStorageEncryptionSecret(log logr.Logger, ctx 
 			Finalizers: []string{storageEncryptionKeyFinalizerName},
 		},
 		StringData: map[string]string{
+			// lighbits storage key name
 			"host-encryption-passphrase": k,
+			// ontap storage key name
+			"luks-passphrase":      k,
+			"luks-passphrase-name": "postgreslet",
 		},
 	}
 


### PR DESCRIPTION
This PR allows the provisioned databases to use another encrypted storage class