### PR TITLE
Add feature flag for migration from endpoints to configmaps

### DIFF
--- a/main.go
+++ b/main.go
@@ -102,6 +102,7 @@ const (
 	podTopologySpreadConstraintMaxSkewFlg       = "pod-topology-spread-constraint-max-skew"
 	podTopologySpreadConstraintMinDomainsFlg    = "pod-topology-spread-constraint-min-domains"
 	enableSpiloReadinessProbeFlg                = "enable-spilo-readiness-probe"
+	enableKubernetesUseConfigMapsFlg            = "enable-kubernetes-use-configmaps"
 )
 
 var (
@@ -172,6 +173,7 @@ func main() {
 		podAntiaffinityPreferredDuringScheduling bool
 		enablePodTopologySpreadConstraintWebhook bool
 		enableSpiloReadinessProbe                bool
+		enableKubernetesUseConfigMaps            bool
 
 		portRangeStart                        int32
 		portRangeSize                         int32
@@ -377,6 +379,9 @@ func main() {
 	viper.SetDefault(enableSpiloReadinessProbeFlg, false)
 	enableSpiloReadinessProbe = viper.GetBool(enableSpiloReadinessProbeFlg)
 
+	viper.SetDefault(enableKubernetesUseConfigMapsFlg, false)
+	enableKubernetesUseConfigMaps = viper.GetBool(enableKubernetesUseConfigMapsFlg)
+
 	ctrl.Log.Info("flag",
 		metricsAddrSvcMgrFlg, metricsAddrSvcMgr,
 		metricsAddrCtrlMgrFlg, metricsAddrCtrlMgr,
@@ -433,6 +438,7 @@ func main() {
 		podTopologySpreadConstraintMaxSkewFlg, podTopologySpreadConstraintMaxSkew,
 		podTopologySpreadConstraintMinDomainsFlg, podTopologySpreadConstraintMinDomains,
 		enableSpiloReadinessProbeFlg, enableSpiloReadinessProbe,
+		enableKubernetesUseConfigMapsFlg, enableKubernetesUseConfigMaps,
 	)
 
 	svcClusterConf := ctrl.GetConfigOrDie()
@@ -507,6 +513,7 @@ func main() {
 		PodAntiaffinityPreferredDuringScheduling: podAntiaffinityPreferredDuringScheduling,
 		PodAntiaffinityTopologyKey:               podAntiaffinityTopologyKey,
 		EnableReadinessProbe:                     enableSpiloReadinessProbe,
+		KubernetesUseConfigMaps:                  enableKubernetesUseConfigMaps,
 	}
 	opMgr, err := operatormanager.New(svcClusterConf, "external/svc-postgres-operator.yaml", scheme, ctrl.Log.WithName("OperatorManager"), opMgrOpts)
 	if err != nil {

--- a/pkg/operatormanager/operatormanager.go
+++ b/pkg/operatormanager/operatormanager.go
@@ -73,6 +73,7 @@ type Options struct {
 	PodAntiaffinityPreferredDuringScheduling bool
 	PodAntiaffinityTopologyKey               string
 	EnableReadinessProbe                     bool
+	KubernetesUseConfigMaps                  bool
 }
 
 // OperatorManager manages the operator
@@ -461,6 +462,8 @@ func (m *OperatorManager) editConfigMap(cm *corev1.ConfigMap, namespace string, 
 		cm.Data["enable_readiness_probe"] = strconv.FormatBool(true)
 		cm.Data["pod_management_policy"] = "parallel"
 	}
+
+	cm.Data["kubernetes_use_configmaps"] = strconv.FormatBool(options.KubernetesUseConfigMaps)
 
 }
 


### PR DESCRIPTION
See:
* https://github.com/zalando/postgres-operator/releases/tag/v1.15.0
* https://github.com/zalando/postgres-operator/issues/2946
* https://github.com/zalando/postgres-operator/pull/2961
* https://kubernetes.io/blog/2025/04/24/endpoints-deprecation/