### PR TITLE
Reduce CPU Requests

### DIFF
--- a/api/v1/postgres_types.go
+++ b/api/v1/postgres_types.go
@@ -712,6 +712,9 @@ func (p *Postgres) ToUnstructuredZalandoPostgresql(z *zalando.Postgresql, c *cor
 
 	z.Spec.Resources = &zalando.Resources{}
 	cpuReq, err := p.calculateCPURequests(p.Spec.Size.CPU, cpuRequestsPercentage)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert to unstructured zalando postgresql: %w", err)
+	}
 	z.Spec.Resources.ResourceRequests.CPU = ptr.To(cpuReq)
 	z.Spec.Resources.ResourceRequests.Memory = ptr.To(p.Spec.Size.Memory)
 	z.Spec.Resources.ResourceLimits.CPU = ptr.To(p.Spec.Size.CPU)

--- a/api/v1/postgres_types.go
+++ b/api/v1/postgres_types.go
@@ -1109,12 +1109,6 @@ func (p *Postgres) DisableLoadBalancers() bool {
 }
 
 func (p *Postgres) calculateCPURequests(c string, percentage int) (string, error) {
-
-	// enforce a minimum percentage
-	if percentage < 33 {
-		percentage = 33
-	}
-
 	// parse the provided cpu quantity
 	cpu, err := resource.ParseQuantity(c)
 	if err != nil {

--- a/api/v1/postgres_types.go
+++ b/api/v1/postgres_types.go
@@ -1108,8 +1108,8 @@ func (p *Postgres) DisableLoadBalancers() bool {
 func (p *Postgres) calculateCPURequests(c string, percentage int) (string, error) {
 
 	// enforce a minimum percentage
-	if percentage < 50 {
-		percentage = 50
+	if percentage < 33 {
+		percentage = 33
 	}
 
 	// parse the provided cpu quantity

--- a/api/v1/postgres_types.go
+++ b/api/v1/postgres_types.go
@@ -675,7 +675,7 @@ func (p *Postgres) ToPeripheralResourceLookupKey() types.NamespacedName {
 	}
 }
 
-func (p *Postgres) ToUnstructuredZalandoPostgresql(z *zalando.Postgresql, c *corev1.ConfigMap, sc string, pgParamBlockList map[string]bool, rbs *BackupConfig, srcDB *Postgres, patroniTTL, patroniLoopWait, patroniRetryTimeout uint32, dboIsSuperuser bool, enableTlsCert bool, image string) (*unstructured.Unstructured, error) {
+func (p *Postgres) ToUnstructuredZalandoPostgresql(z *zalando.Postgresql, c *corev1.ConfigMap, sc string, pgParamBlockList map[string]bool, rbs *BackupConfig, srcDB *Postgres, patroniTTL, patroniLoopWait, patroniRetryTimeout uint32, dboIsSuperuser bool, enableTlsCert bool, image string, cpuRequestsPercentage int) (*unstructured.Unstructured, error) {
 	if z == nil {
 		z = &zalando.Postgresql{}
 	}
@@ -711,7 +711,7 @@ func (p *Postgres) ToUnstructuredZalandoPostgresql(z *zalando.Postgresql, c *cor
 	setSharedBufferSize(z.Spec.PostgresqlParam.Parameters, p.Spec.Size.SharedBuffer)
 
 	z.Spec.Resources = &zalando.Resources{}
-	cpuReq, err := p.calculateCPURequests(p.Spec.Size.CPU, 66)
+	cpuReq, err := p.calculateCPURequests(p.Spec.Size.CPU, cpuRequestsPercentage)
 	z.Spec.Resources.ResourceRequests.CPU = ptr.To(cpuReq)
 	z.Spec.Resources.ResourceRequests.Memory = ptr.To(p.Spec.Size.Memory)
 	z.Spec.Resources.ResourceLimits.CPU = ptr.To(p.Spec.Size.CPU)

--- a/api/v1/postgres_types.go
+++ b/api/v1/postgres_types.go
@@ -711,7 +711,8 @@ func (p *Postgres) ToUnstructuredZalandoPostgresql(z *zalando.Postgresql, c *cor
 	setSharedBufferSize(z.Spec.PostgresqlParam.Parameters, p.Spec.Size.SharedBuffer)
 
 	z.Spec.Resources = &zalando.Resources{}
-	z.Spec.Resources.ResourceRequests.CPU = ptr.To(p.Spec.Size.CPU)
+	cpuReq, err := p.calculateCPURequests(p.Spec.Size.CPU, 66)
+	z.Spec.Resources.ResourceRequests.CPU = ptr.To(cpuReq)
 	z.Spec.Resources.ResourceRequests.Memory = ptr.To(p.Spec.Size.Memory)
 	z.Spec.Resources.ResourceLimits.CPU = ptr.To(p.Spec.Size.CPU)
 	z.Spec.Resources.ResourceLimits.Memory = ptr.To(p.Spec.Size.Memory)
@@ -1102,4 +1103,27 @@ func (p *Postgres) DisableLoadBalancers() bool {
 	}
 
 	return *p.Spec.DisableLoadBalancers
+}
+
+func (p *Postgres) calculateCPURequests(c string, percentage int) (string, error) {
+
+	// enforce a minimum percentage
+	if percentage < 50 {
+		percentage = 50
+	}
+
+	// parse the provided cpu quantity
+	cpu, err := resource.ParseQuantity(c)
+	if err != nil {
+		return "", err
+	}
+
+	// convert the cpu quantity to millis
+	milliValue := cpu.MilliValue()
+
+	// calculate the percentage
+	value := int64((milliValue / int64(100)) * int64(percentage))
+
+	//return the calculated cpu request, making sure it is not higher than the given input value
+	return resource.NewMilliQuantity(min(value, milliValue), resource.BinarySI).String(), nil
 }

--- a/api/v1/postgres_types_test.go
+++ b/api/v1/postgres_types_test.go
@@ -436,13 +436,6 @@ func Test_calculateCPURequests(t *testing.T) {
 			expectedResult:  "",
 			expectErr:       true,
 		},
-		{
-			name:            "LowPercentage",
-			inputValue:      "3",
-			inputPercentage: 15,
-			expectedResult:  "990m",
-			expectErr:       false,
-		},
 	}
 	for _, tt := range tests {
 		tt := tt // pin!

--- a/api/v1/postgres_types_test.go
+++ b/api/v1/postgres_types_test.go
@@ -438,9 +438,9 @@ func Test_calculateCPURequests(t *testing.T) {
 		},
 		{
 			name:            "LowPercentage",
-			inputValue:      "2",
-			inputPercentage: 25,
-			expectedResult:  "1",
+			inputValue:      "3",
+			inputPercentage: 15,
+			expectedResult:  "990m",
 			expectErr:       false,
 		},
 	}

--- a/api/v1/postgres_types_test.go
+++ b/api/v1/postgres_types_test.go
@@ -383,7 +383,7 @@ func TestPostgresRestoreTimestamp_ToUnstructuredZalandoPostgresql(t *testing.T) 
 			p := &Postgres{
 				Spec: tt.spec,
 			}
-			got, _ := p.ToUnstructuredZalandoPostgresql(nil, tt.c, tt.sc, tt.pgParamBlockList, tt.rbs, tt.srcDB, 130, 10, 60, false, false, "dockerImage")
+			got, _ := p.ToUnstructuredZalandoPostgresql(nil, tt.c, tt.sc, tt.pgParamBlockList, tt.rbs, tt.srcDB, 130, 10, 60, false, false, "dockerImage", 66)
 
 			jsonZ, err := runtime.DefaultUnstructuredConverter.ToUnstructured(got)
 			if err != nil {

--- a/api/v1/postgres_types_test.go
+++ b/api/v1/postgres_types_test.go
@@ -436,6 +436,13 @@ func Test_calculateCPURequests(t *testing.T) {
 			expectedResult:  "",
 			expectErr:       true,
 		},
+		{
+			name:            "Same",
+			inputValue:      "1",
+			inputPercentage: 100,
+			expectedResult:  "1",
+			expectErr:       false,
+		},
 	}
 	for _, tt := range tests {
 		tt := tt // pin!

--- a/api/v1/postgres_types_test.go
+++ b/api/v1/postgres_types_test.go
@@ -398,3 +398,70 @@ func TestPostgresRestoreTimestamp_ToUnstructuredZalandoPostgresql(t *testing.T) 
 		})
 	}
 }
+
+func Test_calculateCPURequests(t *testing.T) {
+
+	tests := []struct {
+		name            string
+		inputValue      string
+		inputPercentage int
+		expectedResult  string
+		expectErr       bool
+	}{
+		{
+			name:            "Normal",
+			inputValue:      "1",
+			inputPercentage: 66,
+			expectedResult:  "660m",
+			expectErr:       false,
+		},
+		{
+			name:            "Millis",
+			inputValue:      "4000m",
+			inputPercentage: 75,
+			expectedResult:  "3",
+			expectErr:       false,
+		},
+		{
+			name:            "MoreThan100",
+			inputValue:      "1",
+			inputPercentage: 150,
+			expectedResult:  "1",
+			expectErr:       false,
+		},
+		{
+			name:            "EmptyValue",
+			inputValue:      "",
+			inputPercentage: 66,
+			expectedResult:  "",
+			expectErr:       true,
+		},
+		{
+			name:            "LowPercentage",
+			inputValue:      "2",
+			inputPercentage: 25,
+			expectedResult:  "1",
+			expectErr:       false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt // pin!
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Postgres{
+				Spec: PostgresSpec{
+					ProjectID: tt.name,
+				},
+			}
+
+			result, err := p.calculateCPURequests(tt.inputValue, tt.inputPercentage)
+
+			if err != nil && !tt.expectErr {
+				t.Errorf("Unexpected error")
+			}
+
+			if tt.expectedResult != result {
+				t.Errorf("Calculated CPU request was %v, but expected %v", tt.expectedResult, result)
+			}
+		})
+	}
+}

--- a/controllers/postgres_controller.go
+++ b/controllers/postgres_controller.go
@@ -113,6 +113,7 @@ type PostgresReconciler struct {
 	WalGExporterImage                   string
 	WalGExporterCPULimit                string
 	WalGExporterMemoryLimit             string
+	SpiloCpuRequestsPercentage          int
 }
 
 type PatroniStandbyCluster struct {
@@ -443,7 +444,7 @@ func (r *PostgresReconciler) createOrUpdateZalandoPostgresql(ctx context.Context
 			return fmt.Errorf("failed to fetch zalando postgresql: %w", err)
 		}
 
-		u, err := instance.ToUnstructuredZalandoPostgresql(nil, sidecarsCM, r.StorageClass, r.PgParamBlockList, restoreBackupConfig, restoreSourceInstance, patroniTTL, patroniLoopWait, patroniRetryTimeout, r.EnableSuperUserForDBO, r.EnableCustomTLSCert, r.PostgresImage)
+		u, err := instance.ToUnstructuredZalandoPostgresql(nil, sidecarsCM, r.StorageClass, r.PgParamBlockList, restoreBackupConfig, restoreSourceInstance, patroniTTL, patroniLoopWait, patroniRetryTimeout, r.EnableSuperUserForDBO, r.EnableCustomTLSCert, r.PostgresImage, r.SpiloCpuRequestsPercentage)
 		if err != nil {
 			return fmt.Errorf("failed to convert to unstructured zalando postgresql: %w", err)
 		}
@@ -459,7 +460,7 @@ func (r *PostgresReconciler) createOrUpdateZalandoPostgresql(ctx context.Context
 	// Update zalando postgresql
 	mergeFrom := client.MergeFrom(rawZ.DeepCopy())
 
-	u, err := instance.ToUnstructuredZalandoPostgresql(rawZ, sidecarsCM, r.StorageClass, r.PgParamBlockList, restoreBackupConfig, restoreSourceInstance, patroniTTL, patroniLoopWait, patroniRetryTimeout, r.EnableSuperUserForDBO, r.EnableCustomTLSCert, r.PostgresImage)
+	u, err := instance.ToUnstructuredZalandoPostgresql(rawZ, sidecarsCM, r.StorageClass, r.PgParamBlockList, restoreBackupConfig, restoreSourceInstance, patroniTTL, patroniLoopWait, patroniRetryTimeout, r.EnableSuperUserForDBO, r.EnableCustomTLSCert, r.PostgresImage, r.SpiloCpuRequestsPercentage)
 	if err != nil {
 		return fmt.Errorf("failed to convert to unstructured zalando postgresql: %w", err)
 	}

--- a/main.go
+++ b/main.go
@@ -385,7 +385,7 @@ func main() {
 	enableKubernetesUseConfigMaps = viper.GetBool(enableKubernetesUseConfigMapsFlg)
 
 	// user defined value
-	viper.SetDefault(spiloCpuRequestsPercentageFlag, 66)
+	viper.SetDefault(spiloCpuRequestsPercentageFlag, 50)
 	spiloCpuRequestsPercentage = viper.GetInt(spiloCpuRequestsPercentageFlag)
 
 	ctrl.Log.Info("flag",

--- a/main.go
+++ b/main.go
@@ -103,6 +103,7 @@ const (
 	podTopologySpreadConstraintMinDomainsFlg    = "pod-topology-spread-constraint-min-domains"
 	enableSpiloReadinessProbeFlg                = "enable-spilo-readiness-probe"
 	enableKubernetesUseConfigMapsFlg            = "enable-kubernetes-use-configmaps"
+	spiloCpuRequestsPercentageFlag              = "spilo-cpu-requests-percentage"
 )
 
 var (
@@ -180,6 +181,7 @@ func main() {
 		replicationChangeRequeueTimeInSeconds int
 		podTopologySpreadConstraintMaxSkew    int32
 		podTopologySpreadConstraintMinDomains int32
+		spiloCpuRequestsPercentage            int
 
 		patroniTTL          uint32
 		patroniLoopWait     uint32
@@ -382,6 +384,10 @@ func main() {
 	viper.SetDefault(enableKubernetesUseConfigMapsFlg, false)
 	enableKubernetesUseConfigMaps = viper.GetBool(enableKubernetesUseConfigMapsFlg)
 
+	// user defined value
+	viper.SetDefault(spiloCpuRequestsPercentageFlag, 66)
+	spiloCpuRequestsPercentage = viper.GetInt(spiloCpuRequestsPercentageFlag)
+
 	ctrl.Log.Info("flag",
 		metricsAddrSvcMgrFlg, metricsAddrSvcMgr,
 		metricsAddrCtrlMgrFlg, metricsAddrCtrlMgr,
@@ -439,6 +445,7 @@ func main() {
 		podTopologySpreadConstraintMinDomainsFlg, podTopologySpreadConstraintMinDomains,
 		enableSpiloReadinessProbeFlg, enableSpiloReadinessProbe,
 		enableKubernetesUseConfigMapsFlg, enableKubernetesUseConfigMaps,
+		spiloCpuRequestsPercentageFlag, spiloCpuRequestsPercentage,
 	)
 
 	svcClusterConf := ctrl.GetConfigOrDie()
@@ -565,6 +572,7 @@ func main() {
 		WalGExporterImage:                   walGExporterImage,
 		WalGExporterCPULimit:                walGExporterCPULimit,
 		WalGExporterMemoryLimit:             walGExporterMemoryLimit,
+		SpiloCpuRequestsPercentage:          spiloCpuRequestsPercentage,
 	}).SetupWithManager(ctrlPlaneClusterMgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Postgres")
 		os.Exit(1)


### PR DESCRIPTION
Currently, the cpu requests are identical to the cpu limits for the spilo pods.

But since the read-only replicas do not require as much cpu as the primary pod, we can probably safely reduce the cpu requests.

By default, we now set it to 66% of the CPU limit, but that percentage is configurable.

~~We also check for a certain minimum percentage.~~